### PR TITLE
feat: add Supabase Storage for audit file uploads

### DIFF
--- a/.claude/commands/e2e/test_audit_extraction_fix.md
+++ b/.claude/commands/e2e/test_audit_extraction_fix.md
@@ -1,0 +1,140 @@
+# E2E Test: Audit Extraction Fix Validation
+
+## Overview
+
+This E2E test validates that the audit extraction bug fix is working correctly. The fix addresses the issue where PDF uploads would fail with "Extraction failed. The audit document could not be processed." due to missing `pdf2image` dependency and incorrect handling of `file://` URLs.
+
+## User Story
+
+As a sourcing manager, I want to upload factory audit PDFs and have them processed successfully so that I can view extracted supplier information without encountering extraction errors.
+
+## Prerequisites
+
+- Application running (frontend on port 5173, backend on port 8000)
+- Test user credentials available
+- Test PDF file available for upload
+- `poppler-utils` installed on the system (`sudo apt-get install poppler-utils`)
+- `pdf2image` Python package installed
+- At least one supplier in the database
+- `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` configured in `.env` (optional - extraction will complete but with empty data if not set)
+
+## Test Scenarios
+
+### Scenario 1: Successful PDF Upload and Processing
+
+**Objective:** Verify that PDF upload no longer fails with "Extraction failed" error.
+
+#### Steps
+
+1. **Navigate to Suppliers Page**
+   - Open application at http://localhost:5173
+   - Login with test credentials
+   - Navigate to `/suppliers` page
+   - **Verify** page title "Suppliers" is visible
+   - **Screenshot**: `01_suppliers_page.png`
+
+2. **Open Supplier for Editing**
+   - Click the edit (pencil) icon or three-dot menu on any supplier
+   - **Verify** supplier dialog opens
+   - **Screenshot**: `02_supplier_dialog.png`
+
+3. **Switch to Certification Tab**
+   - Click on "Certification" tab
+   - **Verify** tab is active and upload area is visible
+   - **Screenshot**: `03_certification_tab.png`
+
+4. **Upload a PDF File**
+   - Click the upload area or drag-and-drop a test PDF file
+   - **Verify** upload progress indicator appears
+   - **Verify** status changes to "Processing..."
+   - **Screenshot**: `04_upload_processing.png`
+
+5. **Wait for Extraction to Complete**
+   - Wait up to 60 seconds for processing to finish
+   - **Critical Check**: The error "Extraction failed. The audit document could not be processed." should NOT appear
+   - **Verify** one of the following occurs:
+     - Audit Summary Card appears with extracted data (if AI API key configured)
+     - Audit Summary Card appears with "AI service not available" message (if no API key)
+   - **Screenshot**: `05_extraction_complete.png`
+
+6. **Verify No Error State**
+   - **Verify** the red error alert is NOT visible
+   - **Verify** "Reprocess" button is available (indicates extraction completed, even if empty)
+   - **Screenshot**: `06_no_error_state.png`
+
+### Scenario 2: Verify Local File Reading Works
+
+**Objective:** Confirm that the backend correctly reads files from local `file://` URLs.
+
+#### Steps
+
+7. **Check Backend Logs**
+   - Open the backend terminal
+   - Look for log messages like:
+     - `INFO [AuditService]: Fetching document from file:///tmp/...`
+     - `INFO [AuditService]: Read XXXX bytes`
+     - NOT `ERROR [AuditService]: httpx client error` or similar
+   - **Verify** no httpx-related errors for file:// URLs
+
+### Scenario 3: Error Handling for Missing Dependencies
+
+**Objective:** Verify informative error messages when dependencies are missing.
+
+#### Steps (Only if testing dependency errors)
+
+8. **Test Without Poppler (if applicable)**
+   - If poppler is not installed, upload a PDF
+   - **Verify** error message mentions "poppler-utils" with installation instructions
+   - **Verify** error is user-friendly, not a raw stack trace
+
+## Success Criteria Checklist
+
+- [ ] PDF file uploads successfully (no immediate errors)
+- [ ] Processing status shows "Processing..." during extraction
+- [ ] **CRITICAL**: "Extraction failed" error does NOT appear for valid PDFs
+- [ ] Backend logs show successful file reading from file:// URLs
+- [ ] Audit record is created with status "completed" (not "failed")
+- [ ] If AI API configured: extracted data displays in summary card
+- [ ] If no AI API: summary card shows "AI service not available" but no hard failure
+- [ ] Reprocess button is functional
+- [ ] No console errors in browser
+
+## Manual Verification Steps
+
+1. Start the application:
+   ```bash
+   # Terminal 1 - Backend
+   cd apps/Server
+   source .venv/bin/activate
+   python -m uvicorn main:app --reload --host 0.0.0.0 --port 8000
+
+   # Terminal 2 - Frontend
+   cd apps/Client
+   npm run dev -- --host 0.0.0.0
+   ```
+
+2. Verify dependencies:
+   ```bash
+   # Check poppler
+   which pdftoppm
+
+   # Check pdf2image
+   cd apps/Server && .venv/bin/pip list | grep pdf2image
+   ```
+
+3. Upload a test PDF and monitor backend logs for:
+   - `INFO [AuditService]: Fetching document from file://...`
+   - `INFO [AuditService]: Read XXXX bytes`
+   - `INFO [AuditService]: Converted X PDF pages to images`
+   - `INFO [AuditService]: Extraction completed for audit ...`
+
+## Notes
+
+- The fix resolves the issue where `httpx` cannot fetch `file://` URLs
+- Local file reading is now handled separately from remote URL fetching
+- Better error messages are provided for missing `pdf2image` or `poppler-utils`
+- If extraction still fails, check:
+  1. Is `poppler-utils` installed?
+  2. Is `pdf2image` installed?
+  3. Are AI API keys configured in `.env`?
+  4. Check backend logs for specific error messages

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Brief description of your project.
 - Node.js 18+
 - Python 3.11.9
 - uv (Python package manager)
+- poppler-utils (required for PDF processing in Supplier Certification)
+  - Ubuntu/Debian: `sudo apt-get install poppler-utils`
+  - macOS: `brew install poppler`
+  - Windows: Download from [poppler releases](https://github.com/osber/poppler-windows/releases) and add to PATH
 
 ### Setup
 

--- a/apps/Server/Dockerfile
+++ b/apps/Server/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+# Install system dependencies for PDF processing
+RUN apt-get update && apt-get install -y \
+    poppler-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port (Render will set PORT environment variable)
+EXPOSE 8000
+
+# Run the application
+CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/apps/Server/app/config/settings.py
+++ b/apps/Server/app/config/settings.py
@@ -32,6 +32,11 @@ class Settings(BaseSettings):
     EXTRACTION_MAX_RETRIES: int = 3
     EXTRACTION_TIMEOUT_SECONDS: int = 60
 
+    # Supabase Storage
+    SUPABASE_URL: Optional[str] = None
+    SUPABASE_SERVICE_KEY: Optional[str] = None
+    SUPABASE_STORAGE_BUCKET: str = "audits"
+
     def get_cors_origins(self) -> List[str]:
         """Parse CORS_ORIGINS from JSON string to list."""
         try:

--- a/apps/Server/app/services/storage_service.py
+++ b/apps/Server/app/services/storage_service.py
@@ -1,0 +1,138 @@
+"""Supabase Storage service for file uploads."""
+
+import uuid
+
+from app.config.settings import get_settings
+
+
+class StorageService:
+    """Service for uploading files to Supabase Storage."""
+
+    def __init__(self) -> None:
+        """Initialize the storage service."""
+        self._client = None
+
+    def _get_client(self):
+        """Lazily initialize Supabase client.
+
+        Returns:
+            Supabase client or None if not configured.
+        """
+        if self._client is None:
+            settings = get_settings()
+            if settings.SUPABASE_URL and settings.SUPABASE_SERVICE_KEY:
+                try:
+                    from supabase import create_client
+
+                    self._client = create_client(
+                        settings.SUPABASE_URL,
+                        settings.SUPABASE_SERVICE_KEY,
+                    )
+                    print("INFO [StorageService]: Supabase client initialized")
+                except Exception as e:
+                    print(f"ERROR [StorageService]: Failed to initialize Supabase client: {e}")
+                    self._client = None
+        return self._client
+
+    def upload_file(
+        self,
+        file_content: bytes,
+        file_name: str,
+        content_type: str = "application/pdf",
+        folder: str = "audits",
+    ) -> str:
+        """Upload file to Supabase Storage and return public URL.
+
+        Args:
+            file_content: The file content as bytes.
+            file_name: Original filename.
+            content_type: MIME type of the file.
+            folder: Folder path within the bucket.
+
+        Returns:
+            Public HTTPS URL of the uploaded file.
+
+        Raises:
+            RuntimeError: If Supabase Storage is not configured.
+            Exception: If upload fails.
+        """
+        client = self._get_client()
+        if not client:
+            raise RuntimeError("Supabase Storage not configured")
+
+        # Generate unique path to avoid collisions
+        unique_id = uuid.uuid4().hex
+        safe_filename = file_name.replace(" ", "_")
+        unique_path = f"{folder}/{unique_id}_{safe_filename}"
+
+        settings = get_settings()
+        bucket = settings.SUPABASE_STORAGE_BUCKET
+
+        print(f"INFO [StorageService]: Uploading file to bucket '{bucket}' at path '{unique_path}'")
+
+        try:
+            # Upload to storage
+            client.storage.from_(bucket).upload(
+                unique_path,
+                file_content,
+                {"content-type": content_type},
+            )
+
+            # Get public URL
+            url = client.storage.from_(bucket).get_public_url(unique_path)
+            print(f"INFO [StorageService]: Upload successful, URL: {url}")
+
+            return url
+
+        except Exception as e:
+            print(f"ERROR [StorageService]: Upload failed: {e}")
+            raise
+
+    def delete_file(self, file_url: str) -> bool:
+        """Delete file from Supabase Storage.
+
+        Args:
+            file_url: The public URL of the file to delete.
+
+        Returns:
+            True if deletion was successful, False otherwise.
+        """
+        client = self._get_client()
+        if not client:
+            print("WARN [StorageService]: Cannot delete file - Supabase not configured")
+            return False
+
+        settings = get_settings()
+        bucket = settings.SUPABASE_STORAGE_BUCKET
+
+        # Extract path from URL
+        # URL format: https://<project>.supabase.co/storage/v1/object/public/<bucket>/<path>
+        try:
+            # Find the bucket name in the URL and extract the path after it
+            bucket_marker = f"/public/{bucket}/"
+            if bucket_marker in file_url:
+                path = file_url.split(bucket_marker)[1]
+            else:
+                print(f"WARN [StorageService]: Could not extract path from URL: {file_url}")
+                return False
+
+            print(f"INFO [StorageService]: Deleting file at path '{path}'")
+            client.storage.from_(bucket).remove([path])
+            return True
+
+        except Exception as e:
+            print(f"ERROR [StorageService]: Delete failed: {e}")
+            return False
+
+    def is_configured(self) -> bool:
+        """Check if Supabase Storage is properly configured.
+
+        Returns:
+            True if SUPABASE_URL and SUPABASE_SERVICE_KEY are set.
+        """
+        settings = get_settings()
+        return bool(settings.SUPABASE_URL and settings.SUPABASE_SERVICE_KEY)
+
+
+# Singleton instance
+storage_service = StorageService()

--- a/apps/Server/requirements.txt
+++ b/apps/Server/requirements.txt
@@ -35,9 +35,13 @@ ruff>=0.1.0
 anthropic>=0.7.0
 openai>=1.3.0
 pypdf2>=3.0.0
+pdf2image>=2.16.0
 openpyxl>=3.1.0
 pillow>=10.0.0
 
 # PDF Generation
 reportlab>=4.0.0
 qrcode[pil]>=7.4.0
+
+# Cloud Storage
+supabase>=2.0.0

--- a/specs/bug-audit-extraction-failed-processing.md
+++ b/specs/bug-audit-extraction-failed-processing.md
@@ -1,0 +1,175 @@
+# Bug: Audit Extraction Failed - PDF Processing Error
+
+## Metadata
+issue_number: ``
+adw_id: ``
+issue_json: ``
+
+## Bug Description
+When uploading a PDF file for the supplier audit process, the system shows "Processing..." but then displays the error: "Extraction failed. The audit document could not be processed." The file uploads successfully, but the AI extraction step fails silently in the background, causing the audit to remain stuck with a `failed` extraction status.
+
+**Expected behavior:** After uploading a factory audit PDF, the system should extract key data (supplier type, employee count, certifications, etc.) and display the audit summary.
+
+**Actual behavior:** Upload succeeds but extraction fails, leaving the user with an error message and no extracted data.
+
+## Problem Statement
+The audit extraction process fails because:
+1. **Missing dependency**: `pdf2image` package is used in the code but not listed in `requirements.txt`
+2. **Invalid URL scheme**: Documents are stored with `file://` URLs, but `httpx` cannot fetch local file URLs
+3. **Missing system dependency**: `pdf2image` requires `poppler-utils` to be installed on the system
+
+## Solution Statement
+Fix the extraction pipeline by:
+1. Adding `pdf2image` to `requirements.txt`
+2. Modifying `process_audit()` to read local files directly instead of using httpx for `file://` URLs
+3. Adding proper error handling with informative messages
+4. Documenting the `poppler-utils` system dependency requirement
+
+## Steps to Reproduce
+1. Start the application (`/start`)
+2. Navigate to Kompass > Suppliers
+3. Click edit on any supplier
+4. Go to the "Certification" tab
+5. Upload a factory audit PDF file (any valid PDF)
+6. Observe "Processing..." appears briefly
+7. After ~5-10 seconds, the error message appears: "Extraction failed. The audit document could not be processed."
+
+## Root Cause Analysis
+Looking at `apps/Server/app/services/audit_service.py`:
+
+1. **Line 245-286**: `_convert_pdf_to_images()` uses `from pdf2image import convert_from_bytes` but `pdf2image` is not in `requirements.txt`
+
+2. **Line 350-360**: `process_audit()` tries to fetch the document using httpx:
+```python
+document_url = audit_data["document_url"]  # "file:///tmp/audit_xxx.pdf"
+with httpx.Client(timeout=120.0) as client:
+    response = client.get(document_url)  # FAILS - httpx doesn't support file:// URLs
+```
+
+3. **Line 419-431**: When extraction fails, it catches the exception and sets status to `failed`, but the error is not user-friendly
+
+4. In `audit_routes.py` line 127, the URL is created as:
+```python
+document_url = f"file://{temp_path}"  # e.g., "file:///tmp/audit_xyz.pdf"
+```
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `apps/Server/app/services/audit_service.py` - Contains `process_audit()` method that fails when fetching file:// URLs and uses pdf2image
+- `apps/Server/app/api/audit_routes.py` - Creates the file:// URL when uploading documents
+- `apps/Server/requirements.txt` - Missing `pdf2image` dependency
+- `apps/Server/app/config/settings.py` - Contains AI provider configuration (ANTHROPIC_API_KEY, OPENAI_API_KEY)
+- `README.md` - May need to document poppler-utils requirement
+- `ai_docs/PRD-Supplier-Certification-System.md` - Reference for understanding the feature
+- `.claude/commands/test_e2e.md` - Reference for E2E test format
+- `.claude/commands/e2e/test_supplier_certification_workflow.md` - Existing E2E test to reference
+
+### New Files
+- `.claude/commands/e2e/test_audit_extraction_fix.md` - E2E test to validate the bug fix
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Add missing pdf2image dependency
+- Open `apps/Server/requirements.txt`
+- Add `pdf2image>=2.16.0` to the AI & Data Extraction section
+- This package is required for converting PDF pages to images for AI vision processing
+
+### Step 2: Fix file:// URL handling in audit_service.py
+- Open `apps/Server/app/services/audit_service.py`
+- Locate the `process_audit()` method (around line 328)
+- Modify the document fetching logic to handle `file://` URLs by reading the local file directly:
+```python
+# Before the httpx fetch, check if it's a local file
+document_url = audit_data["document_url"]
+if document_url.startswith("file://"):
+    # Read local file directly
+    local_path = document_url[7:]  # Remove "file://" prefix
+    with open(local_path, "rb") as f:
+        pdf_content = f.read()
+else:
+    # Fetch from remote URL
+    with httpx.Client(timeout=120.0) as client:
+        response = client.get(document_url)
+        response.raise_for_status()
+        pdf_content = response.content
+```
+
+### Step 3: Add better error handling and logging
+- In `audit_service.py`, enhance the error handling in `process_audit()`:
+  - Add specific error message when pdf2image import fails
+  - Add specific error message when AI API keys are not configured
+  - Add specific error message when poppler is not installed
+  - Log the actual exception details for debugging
+
+### Step 4: Update README with system dependency documentation
+- Open `README.md` or create `apps/Server/README.md` if needed
+- Add a note about the `poppler-utils` system dependency requirement:
+  - Ubuntu/Debian: `sudo apt-get install poppler-utils`
+  - macOS: `brew install poppler`
+  - Windows: Download from poppler releases and add to PATH
+
+### Step 5: Install dependencies and verify fix
+- Run `cd apps/Server && pip install pdf2image`
+- Ensure `poppler-utils` is installed on the system
+- Verify ANTHROPIC_API_KEY or OPENAI_API_KEY is set in `.env`
+- Test by uploading a PDF and confirming extraction works
+
+### Step 6: Create E2E test for the fix
+- Read `.claude/commands/e2e/test_basic_query.md` and `.claude/commands/e2e/test_supplier_certification_workflow.md`
+- Create `.claude/commands/e2e/test_audit_extraction_fix.md` with steps to:
+  1. Navigate to Suppliers page
+  2. Open a supplier for editing
+  3. Go to Certification tab
+  4. Upload a test PDF file
+  5. Wait for processing to complete (use polling)
+  6. Verify extraction summary appears (not the error message)
+  7. Verify key fields are populated (supplier type, employee count, etc.)
+  8. Take screenshots at each step
+
+### Step 7: Run validation commands
+- Execute all validation commands to ensure the fix works and there are no regressions
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+```bash
+# Check pdf2image is in requirements
+grep -q "pdf2image" apps/Server/requirements.txt && echo "pdf2image found" || echo "pdf2image MISSING"
+
+# Install dependencies
+cd apps/Server && pip install -r requirements.txt
+
+# Verify poppler is installed (required by pdf2image)
+which pdftoppm || echo "WARNING: poppler-utils not installed"
+
+# Run Server tests to validate no regressions
+cd apps/Server && .venv/bin/pytest tests/ -v --tb=short
+
+# Run specific audit service tests
+cd apps/Server && .venv/bin/pytest tests/test_audit_service.py -v --tb=short
+
+# Run audit route tests
+cd apps/Server && .venv/bin/pytest tests/api/test_audit_routes.py -v --tb=short
+
+# Run Client type check
+cd apps/Client && npm run typecheck
+
+# Run Client build
+cd apps/Client && npm run build
+```
+
+Read `.claude/commands/test_e2e.md`, then read and execute the new E2E test `.claude/commands/e2e/test_audit_extraction_fix.md` to validate the extraction works end-to-end.
+
+## Notes
+
+1. **System dependency**: `pdf2image` requires `poppler-utils` to be installed on the system. This is a system-level dependency that cannot be installed via pip.
+
+2. **AI API Keys**: The extraction requires either `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` to be set in the `.env` file. Without these, extraction will mark as "completed" but with empty data.
+
+3. **File storage**: In production, the document should be uploaded to cloud storage (S3/R2/Supabase Storage) and use a proper HTTP URL. The current `file://` URL approach is only for local development.
+
+4. **New package**: Add `pdf2image>=2.16.0` to requirements.txt
+
+5. **Testing**: When running E2E tests, ensure you have a test PDF file available. The extraction quality depends on the PDF content and AI provider performance.

--- a/specs/feature-supabase-storage-audit-uploads.md
+++ b/specs/feature-supabase-storage-audit-uploads.md
@@ -1,0 +1,345 @@
+# Feature: Supabase Storage for Audit File Uploads
+
+## Metadata
+issue_number: ``
+adw_id: ``
+issue_json: ``
+
+## Feature Description
+Integrate Supabase Storage for uploading and storing supplier audit PDF documents. This replaces the current local file storage approach (`file://` URLs) with proper cloud storage that returns HTTPS URLs, enabling reliable PDF processing in production environments like Render.
+
+## Problem Statement
+The current implementation stores uploaded audit PDFs as local temp files with `file://` URLs. This causes issues:
+1. **Local files are ephemeral** - Lost on server restart/redeployment
+2. **file:// URLs don't work with httpx** - Required a workaround to read local files
+3. **Not production-ready** - Render and other cloud platforms don't persist local files
+4. **poppler-utils still needed** - Requires a Dockerfile for the system dependency
+
+## Solution Statement
+1. **Integrate Supabase Storage** for file uploads in `audit_routes.py`
+2. **Store HTTPS URLs** in the database instead of `file://` URLs
+3. **Create a Dockerfile** for Render deployment with `poppler-utils`
+4. **Add storage bucket configuration** via environment variables
+
+## Architecture
+
+### Current Flow (Local Files)
+```
+Upload PDF → Save to /tmp/audit_xxx.pdf → Store "file:///tmp/..." URL → Read local file
+```
+
+### New Flow (Supabase Storage)
+```
+Upload PDF → Upload to Supabase Storage → Get HTTPS URL → Store URL in DB
+                                                ↓
+Background job → Fetch PDF via HTTPS → pdf2image → AI extraction
+```
+
+## Relevant Files
+
+### Files to Modify
+- `apps/Server/app/api/audit_routes.py` - Replace local file storage with Supabase upload
+- `apps/Server/app/services/audit_service.py` - Remove local file:// handling (keep for backwards compatibility)
+- `apps/Server/app/config/settings.py` - Add Supabase Storage configuration
+- `apps/Server/requirements.txt` - Add `supabase` Python SDK
+- `.env.sample` - Add Supabase Storage environment variables
+
+### New Files to Create
+- `apps/Server/app/services/storage_service.py` - Supabase Storage service wrapper
+- `apps/Server/Dockerfile` - Docker image with poppler-utils for Render
+- `apps/Server/render.yaml` - Render deployment configuration (optional)
+
+## Environment Variables
+
+Add to `apps/Server/.env`:
+```bash
+# Supabase Storage
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_KEY=your-service-role-key
+SUPABASE_STORAGE_BUCKET=audits
+```
+
+Note: Use `SUPABASE_SERVICE_KEY` (service role) instead of anon key for server-side uploads with full access.
+
+## Step by Step Tasks
+
+### Step 1: Add Supabase Python SDK to requirements.txt
+- Open `apps/Server/requirements.txt`
+- Add `supabase>=2.0.0` to the dependencies
+- This provides the official Supabase client for Python
+
+### Step 2: Add Supabase Storage settings
+- Open `apps/Server/app/config/settings.py`
+- Add the following settings:
+  ```python
+  # Supabase Storage
+  SUPABASE_URL: Optional[str] = None
+  SUPABASE_SERVICE_KEY: Optional[str] = None
+  SUPABASE_STORAGE_BUCKET: str = "audits"
+  ```
+
+### Step 3: Create Storage Service
+- Create `apps/Server/app/services/storage_service.py`
+- Implement a `StorageService` class with methods:
+  ```python
+  class StorageService:
+      def __init__(self):
+          self._client = None
+
+      def _get_client(self):
+          """Lazily initialize Supabase client."""
+          if self._client is None:
+              from supabase import create_client
+              settings = get_settings()
+              if settings.SUPABASE_URL and settings.SUPABASE_SERVICE_KEY:
+                  self._client = create_client(
+                      settings.SUPABASE_URL,
+                      settings.SUPABASE_SERVICE_KEY
+                  )
+          return self._client
+
+      def upload_file(
+          self,
+          file_content: bytes,
+          file_name: str,
+          content_type: str = "application/pdf",
+          folder: str = "audits"
+      ) -> str:
+          """Upload file to Supabase Storage and return public URL."""
+          client = self._get_client()
+          if not client:
+              raise RuntimeError("Supabase Storage not configured")
+
+          # Generate unique path
+          import uuid
+          unique_name = f"{folder}/{uuid.uuid4().hex}_{file_name}"
+
+          # Upload to storage
+          bucket = get_settings().SUPABASE_STORAGE_BUCKET
+          result = client.storage.from_(bucket).upload(
+              unique_name,
+              file_content,
+              {"content-type": content_type}
+          )
+
+          # Get public URL
+          url = client.storage.from_(bucket).get_public_url(unique_name)
+          return url
+
+      def delete_file(self, file_path: str) -> bool:
+          """Delete file from Supabase Storage."""
+          # Extract path from URL and delete
+          pass
+
+      def is_configured(self) -> bool:
+          """Check if Supabase Storage is properly configured."""
+          settings = get_settings()
+          return bool(settings.SUPABASE_URL and settings.SUPABASE_SERVICE_KEY)
+
+  # Singleton
+  storage_service = StorageService()
+  ```
+
+### Step 4: Update audit_routes.py to use Supabase Storage
+- Open `apps/Server/app/api/audit_routes.py`
+- Import the storage service
+- Modify the `upload_audit` endpoint:
+  ```python
+  from app.services.storage_service import storage_service
+
+  @router.post("/{supplier_id}/audits", ...)
+  async def upload_audit(...):
+      # ... validation code ...
+
+      # Read file content
+      content = await file.read()
+
+      # Upload to Supabase Storage (or fallback to local for dev)
+      if storage_service.is_configured():
+          document_url = storage_service.upload_file(
+              file_content=content,
+              file_name=file.filename or "audit.pdf",
+              content_type="application/pdf",
+              folder=f"suppliers/{supplier_id}/audits"
+          )
+      else:
+          # Fallback to local file for development
+          import tempfile
+          import os
+          ext = os.path.splitext(file.filename or "")[1].lower()
+          with tempfile.NamedTemporaryFile(delete=False, suffix=ext, prefix="audit_") as tmp:
+              tmp.write(content)
+              document_url = f"file://{tmp.name}"
+          print("WARN [AuditRoutes]: Supabase Storage not configured, using local file")
+
+      # Create audit record with URL
+      audit = audit_service.upload_audit(
+          supplier_id=supplier_id,
+          document_url=document_url,
+          document_name=file.filename or "audit.pdf",
+          file_size_bytes=len(content),
+          audit_type=audit_type,
+      )
+      # ... rest of the code ...
+  ```
+
+### Step 5: Create Dockerfile for Render
+- Create `apps/Server/Dockerfile`:
+  ```dockerfile
+  FROM python:3.11-slim
+
+  # Install system dependencies for PDF processing
+  RUN apt-get update && apt-get install -y \
+      poppler-utils \
+      && rm -rf /var/lib/apt/lists/*
+
+  # Set working directory
+  WORKDIR /app
+
+  # Copy requirements first for better caching
+  COPY requirements.txt .
+  RUN pip install --no-cache-dir -r requirements.txt
+
+  # Copy application code
+  COPY . .
+
+  # Expose port
+  EXPOSE 8000
+
+  # Run the application
+  CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+  ```
+
+### Step 6: Update .env.sample
+- Add Supabase Storage variables:
+  ```bash
+  # Supabase Storage (for audit file uploads)
+  SUPABASE_URL=https://your-project.supabase.co
+  SUPABASE_SERVICE_KEY=your-service-role-key
+  SUPABASE_STORAGE_BUCKET=audits
+  ```
+
+### Step 7: Create Supabase Storage Bucket
+- Log into Supabase Dashboard
+- Navigate to Storage
+- Create a new bucket named "audits"
+- Set bucket to "Public" (for PDF viewing) or configure signed URLs
+- Add RLS policies if needed
+
+### Step 8: Update Render deployment settings
+- In Render dashboard, change environment from "Python" to "Docker"
+- Or create `render.yaml` for infrastructure-as-code:
+  ```yaml
+  services:
+    - type: web
+      name: kompass-api
+      env: docker
+      dockerfilePath: ./apps/Server/Dockerfile
+      dockerContext: ./apps/Server
+      envVars:
+        - key: DATABASE_URL
+          sync: false
+        - key: SUPABASE_URL
+          sync: false
+        - key: SUPABASE_SERVICE_KEY
+          sync: false
+        - key: SUPABASE_STORAGE_BUCKET
+          value: audits
+  ```
+
+### Step 9: Test the integration
+- Set up Supabase Storage bucket locally
+- Configure environment variables
+- Upload a test PDF
+- Verify URL is an HTTPS Supabase URL
+- Verify PDF can be fetched and processed
+- Verify extraction works end-to-end
+
+### Step 10: Run validation commands
+- Execute all validation commands to ensure no regressions
+
+## Validation Commands
+
+```bash
+# Verify supabase package is in requirements
+grep -q "supabase" apps/Server/requirements.txt && echo "supabase found" || echo "supabase MISSING"
+
+# Install dependencies
+cd apps/Server && pip install -r requirements.txt
+
+# Run Server tests
+cd apps/Server && .venv/bin/pytest tests/ -v --tb=short
+
+# Run audit-specific tests
+cd apps/Server && .venv/bin/pytest tests/api/test_audit_routes.py -v --tb=short
+cd apps/Server && .venv/bin/pytest tests/test_audit_service.py -v --tb=short
+
+# Run Client type check
+cd apps/Client && npm run typecheck
+
+# Run Client build
+cd apps/Client && npm run build
+
+# Test Docker build locally
+cd apps/Server && docker build -t kompass-api .
+docker run --rm kompass-api which pdftoppm  # Should find poppler
+```
+
+## Supabase Storage Bucket Setup
+
+### Via Supabase Dashboard
+1. Go to your Supabase project dashboard
+2. Navigate to **Storage** in the sidebar
+3. Click **New bucket**
+4. Name: `audits`
+5. Public bucket: **Yes** (for direct PDF viewing)
+6. Click **Create bucket**
+
+### Storage Policies (Optional)
+If you want more control, add RLS policies:
+```sql
+-- Allow authenticated uploads
+CREATE POLICY "Allow authenticated uploads"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (bucket_id = 'audits');
+
+-- Allow public reads
+CREATE POLICY "Allow public reads"
+ON storage.objects FOR SELECT
+TO public
+USING (bucket_id = 'audits');
+```
+
+## File Structure After Implementation
+
+```
+apps/Server/
+├── Dockerfile                          # NEW - Docker image with poppler
+├── requirements.txt                    # MODIFIED - Added supabase
+├── app/
+│   ├── config/
+│   │   └── settings.py                 # MODIFIED - Added Supabase settings
+│   ├── api/
+│   │   └── audit_routes.py             # MODIFIED - Use storage service
+│   └── services/
+│       ├── storage_service.py          # NEW - Supabase Storage wrapper
+│       └── audit_service.py            # (unchanged, file:// fallback kept)
+```
+
+## Rollback Plan
+
+If issues arise:
+1. Remove Supabase Storage configuration from `.env`
+2. The code will fallback to local file storage automatically
+3. Revert Render to Python environment (remove Docker)
+
+## Notes
+
+1. **Service Role Key**: Use `SUPABASE_SERVICE_KEY` (not anon key) for server-side uploads to bypass RLS
+2. **Public vs Private Buckets**: Public bucket allows direct PDF viewing; private requires signed URLs
+3. **File Cleanup**: Consider adding a cleanup job for old/orphaned files
+4. **File Size Limits**: Supabase free tier has 1GB storage limit; Pro has 100GB
+5. **Backwards Compatibility**: The local file:// fallback is kept for local development without Supabase
+6. **Docker Build Time**: First build may take a few minutes; subsequent builds use cache
+7. **Render Pricing**: Docker deployments may use more resources; check Render pricing


### PR DESCRIPTION
- Add supabase Python SDK to requirements.txt
- Create storage_service.py for Supabase Storage uploads
- Update audit_routes.py to use Supabase Storage (with local fallback)
- Add Supabase settings to config (URL, service key, bucket)
- Create Dockerfile with poppler-utils for Render deployment
- Fix file:// URL handling in audit_service.py for local development
- Add better error handling for missing pdf2image/poppler dependencies
- Update README with poppler-utils prerequisite
- Add specs and E2E test documentation