### PR TITLE
fix: correct pdf2image version constraint

### DIFF
--- a/apps/Server/requirements.txt
+++ b/apps/Server/requirements.txt
@@ -35,7 +35,7 @@ ruff>=0.1.0
 anthropic>=0.7.0
 openai>=1.3.0
 pypdf2>=3.0.0
-pdf2image>=2.16.0
+pdf2image>=1.16.0
 openpyxl>=3.1.0
 pillow>=10.0.0
 


### PR DESCRIPTION
pdf2image 2.16.0 doesn't exist - latest is 1.17.0. Changed to >=1.16.0.