### PR TITLE
fix: resolve "Not allowed to load local resource" error when viewing …

### DIFF
--- a/.claude/commands/e2e/test_view_audit_pdf.md
+++ b/.claude/commands/e2e/test_view_audit_pdf.md
@@ -1,0 +1,135 @@
+# E2E Test: View Audit PDF
+
+## Overview
+
+This E2E test validates that the "View Full PDF" button works correctly for audit documents. The fix addresses the issue where clicking "View Full PDF" would fail with "Not allowed to load local resource: file:///tmp/..." because browsers block direct access to local file:// URLs.
+
+## User Story
+
+As a sourcing manager, I want to view the original audit PDF document so that I can review the full audit details and verify extracted information.
+
+## Prerequisites
+
+- Application running (frontend on port 5173, backend on port 8000)
+- Test user credentials available
+- At least one supplier with a completed audit in the database
+- Test PDF file available for upload (if no audit exists)
+
+## Test Scenarios
+
+### Scenario 1: View PDF from Completed Audit
+
+**Objective:** Verify that clicking "View Full PDF" opens the PDF in a new browser tab.
+
+#### Steps
+
+1. **Navigate to Suppliers Page**
+   - Open application at http://localhost:5173
+   - Login with test credentials
+   - Navigate to `/suppliers` page
+   - **Verify** page title "Suppliers" is visible
+   - **Screenshot**: `01_suppliers_page.png`
+
+2. **Open Supplier with Audit**
+   - Click the edit (pencil) icon on a supplier that has a completed audit
+   - **Verify** supplier dialog opens
+   - **Screenshot**: `02_supplier_dialog.png`
+
+3. **Switch to Certification Tab**
+   - Click on "Certification" tab
+   - **Verify** Latest Audit section is visible with audit summary
+   - **Verify** "View Full PDF" button is visible
+   - **Screenshot**: `03_certification_tab_with_audit.png`
+
+4. **Click View Full PDF Button**
+   - Click the "View Full PDF" button
+   - **Verify** a new browser tab opens
+   - **Verify** the PDF content is displayed (or browser's PDF viewer loads)
+   - **Critical Check**: No console error "Not allowed to load local resource"
+   - **Screenshot**: `04_pdf_viewer.png`
+
+5. **Verify No Console Errors**
+   - Open browser developer tools (F12)
+   - Check the Console tab
+   - **Verify** no errors related to "local resource" or "file://"
+   - **Screenshot**: `05_no_console_errors.png`
+
+### Scenario 2: View PDF from Failed Audit (Error State)
+
+**Objective:** Verify the View PDF button works even when extraction failed.
+
+#### Steps
+
+6. **Find Audit with Failed Status**
+   - Navigate to a supplier with a failed audit (if available)
+   - **Verify** the error state shows "Extraction failed"
+   - **Verify** "View Full PDF" button is still visible
+   - **Screenshot**: `06_failed_audit_view_pdf.png`
+
+7. **Click View Full PDF on Failed Audit**
+   - Click the "View Full PDF" button
+   - **Verify** PDF opens in new tab
+   - **Verify** no console errors
+
+### Scenario 3: Verify Backend Download Endpoint
+
+**Objective:** Confirm the backend serves PDF files correctly.
+
+#### Steps
+
+8. **Check Network Request**
+   - Open browser developer tools > Network tab
+   - Click "View Full PDF"
+   - **Verify** request goes to `/api/suppliers/{id}/audits/{id}/download`
+   - **Verify** response is either:
+     - 200 with PDF content (for local files)
+     - 302 redirect to Supabase Storage URL (for cloud files)
+   - **Screenshot**: `07_network_request.png`
+
+## Success Criteria Checklist
+
+- [ ] "View Full PDF" button is visible on completed audits
+- [ ] "View Full PDF" button is visible on failed audits
+- [ ] Clicking button opens PDF in new browser tab
+- [ ] **CRITICAL**: No "Not allowed to load local resource" error in console
+- [ ] PDF content displays correctly in browser
+- [ ] Network request goes to backend `/download` endpoint
+- [ ] Backend returns PDF content or redirects to storage URL
+- [ ] Works for both local file:// URLs and Supabase Storage URLs
+
+## Manual Verification Steps
+
+1. Start the application:
+   ```bash
+   # Terminal 1 - Backend
+   cd apps/Server
+   source .venv/bin/activate
+   python -m uvicorn main:app --reload --host 0.0.0.0 --port 8000
+
+   # Terminal 2 - Frontend
+   cd apps/Client
+   npm run dev -- --host 0.0.0.0
+   ```
+
+2. Test the download endpoint directly:
+   ```bash
+   # Get a valid audit ID from the database or UI
+   curl -I "http://localhost:8000/api/suppliers/{supplier_id}/audits/{audit_id}/download" \
+     -H "Authorization: Bearer {token}"
+
+   # Should return 200 with application/pdf or 302 redirect
+   ```
+
+3. Upload a new PDF and verify View Full PDF works:
+   - Upload PDF via Certification tab
+   - Wait for processing
+   - Click "View Full PDF"
+   - Verify PDF opens without errors
+
+## Notes
+
+- The fix routes PDF viewing through the backend `/download` endpoint
+- For local `file://` URLs, the backend reads and serves the file content
+- For Supabase Storage `https://` URLs, the backend redirects to the storage URL
+- This approach works uniformly regardless of storage location
+- Authentication is still required to access the download endpoint

--- a/apps/Client/src/components/kompass/AuditSummaryCard.tsx
+++ b/apps/Client/src/components/kompass/AuditSummaryCard.tsx
@@ -28,7 +28,7 @@ import type { SupplierAuditResponse } from '@/types/kompass';
 interface AuditSummaryCardProps {
   audit: SupplierAuditResponse;
   onReprocess?: (auditId: string) => void;
-  onViewPdf?: (documentUrl: string) => void;
+  onViewPdf?: (auditId: string) => void;
   onOverrideClick?: () => void;
   showClassification?: boolean;
 }
@@ -116,7 +116,7 @@ const AuditSummaryCard: React.FC<AuditSummaryCardProps> = ({
                 variant="outlined"
                 size="small"
                 startIcon={<VisibilityIcon />}
-                onClick={() => onViewPdf(audit.document_url)}
+                onClick={() => onViewPdf(audit.id)}
               >
                 View Full PDF
               </Button>
@@ -314,7 +314,7 @@ const AuditSummaryCard: React.FC<AuditSummaryCardProps> = ({
               variant="outlined"
               size="small"
               startIcon={<VisibilityIcon />}
-              onClick={() => onViewPdf(audit.document_url)}
+              onClick={() => onViewPdf(audit.id)}
             >
               View Full PDF
             </Button>

--- a/apps/Client/src/components/kompass/SupplierCertificationTab.tsx
+++ b/apps/Client/src/components/kompass/SupplierCertificationTab.tsx
@@ -96,9 +96,13 @@ const SupplierCertificationTab: React.FC<SupplierCertificationTabProps> = ({
     }
   };
 
-  const handleViewPdf = (documentUrl: string) => {
-    console.log(`INFO [SupplierCertificationTab]: Opening PDF: ${documentUrl}`);
-    window.open(documentUrl, '_blank');
+  const handleViewPdf = (auditId: string) => {
+    // Use the backend download endpoint to serve the PDF
+    // This works for both local file:// URLs and Supabase Storage URLs
+    const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000/api';
+    const downloadUrl = `${apiUrl}/suppliers/${supplierId}/audits/${auditId}/download`;
+    console.log(`INFO [SupplierCertificationTab]: Opening PDF via backend: ${downloadUrl}`);
+    window.open(downloadUrl, '_blank');
   };
 
   const handleOverrideClick = (audit: SupplierAuditResponse) => {

--- a/specs/bug-view-pdf-local-file-access-blocked.md
+++ b/specs/bug-view-pdf-local-file-access-blocked.md
@@ -1,0 +1,133 @@
+# Bug: View Full PDF fails with "Not allowed to load local resource"
+
+## Metadata
+issue_number: ``
+adw_id: ``
+issue_json: ``
+
+## Bug Description
+When clicking "View Full PDF" button in the Audit Summary Card, the browser displays an error:
+```
+Not allowed to load local resource: file:///tmp/audit_5l53l2zj.pdf
+```
+
+The expected behavior is that clicking "View Full PDF" should open the PDF document in a new browser tab. Instead, the browser blocks the request because it cannot load local `file://` URLs for security reasons.
+
+## Problem Statement
+The `handleViewPdf` function in `SupplierCertificationTab.tsx` calls `window.open(documentUrl, '_blank')` which works for HTTPS URLs (from Supabase Storage) but fails for `file://` URLs (from local development or legacy audit records).
+
+Browsers block `file://` URLs from web pages for security reasons - a web page cannot access local filesystem resources.
+
+## Solution Statement
+Create a backend API endpoint that serves audit PDF files. For `file://` URLs, read the file from disk and stream it to the client. For HTTPS URLs (Supabase Storage), either redirect to the URL or proxy the request.
+
+The frontend will call this new endpoint instead of trying to open the URL directly.
+
+## Steps to Reproduce
+1. Navigate to Suppliers page
+2. Click edit on any supplier
+3. Go to "Certification" tab
+4. Upload a PDF audit document (when Supabase Storage is not configured)
+5. Wait for processing to complete
+6. Click "View Full PDF" button
+7. **Observe**: Browser console shows "Not allowed to load local resource: file:///tmp/..."
+
+## Root Cause Analysis
+The root cause is a mismatch between storage location and access method:
+
+1. **Local Development Storage**: When Supabase Storage is not configured, audit files are saved to `/tmp/` with `file://` URLs stored in the database
+2. **Browser Security**: Web browsers block `file://` URLs from web pages to prevent security vulnerabilities
+3. **Direct URL Access**: The frontend calls `window.open(documentUrl)` which works for `https://` URLs but fails for `file://` URLs
+
+The fix requires the backend to serve the PDF content, either by:
+- Reading local files and streaming them
+- Redirecting/proxying Supabase Storage URLs
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `apps/Server/app/api/audit_routes.py` - Add new endpoint to serve PDF files
+- `apps/Client/src/components/kompass/SupplierCertificationTab.tsx` - Update `handleViewPdf` to use the new backend endpoint
+- `apps/Client/src/components/kompass/AuditSummaryCard.tsx` - Receives the `onViewPdf` callback (no changes needed, just for context)
+- `apps/Client/src/services/kompassService.ts` - May need to add a method or use direct URL
+- Read `.claude/commands/e2e/test_audit_extraction_fix.md` for E2E test format reference
+
+### New Files
+- `.claude/commands/e2e/test_view_audit_pdf.md` - E2E test to validate PDF viewing works
+
+## Step by Step Tasks
+
+### Step 1: Add PDF download endpoint to audit_routes.py
+- Open `apps/Server/app/api/audit_routes.py`
+- Add a new GET endpoint `/{supplier_id}/audits/{audit_id}/download`
+- The endpoint should:
+  - Verify the audit exists and belongs to the supplier
+  - Get the `document_url` from the audit record
+  - If URL starts with `file://`:
+    - Extract the local path
+    - Read the file content
+    - Return as a StreamingResponse with `application/pdf` content type
+  - If URL starts with `https://`:
+    - Return a RedirectResponse to the Supabase Storage URL
+  - Set appropriate headers: `Content-Disposition: inline; filename="audit.pdf"` for inline viewing
+- Add appropriate authentication (require viewer role or above)
+
+### Step 2: Update frontend to use the new endpoint
+- Open `apps/Client/src/components/kompass/SupplierCertificationTab.tsx`
+- Modify the `handleViewPdf` function to:
+  - Instead of `window.open(documentUrl, '_blank')`
+  - Construct the backend URL: `/api/suppliers/{supplierId}/audits/{auditId}/download`
+  - Open this URL in a new tab: `window.open(backendUrl, '_blank')`
+- Update the `AuditSummaryCard` component usage to pass the audit ID instead of document URL
+  - Change `onViewPdf` callback signature from `(documentUrl: string) => void` to `(auditId: string) => void`
+
+### Step 3: Update AuditSummaryCard props and callback
+- Open `apps/Client/src/components/kompass/AuditSummaryCard.tsx`
+- Change the `onViewPdf` prop type from `(documentUrl: string) => void` to `(auditId: string) => void`
+- Update the button onClick handlers to pass `audit.id` instead of `audit.document_url`
+
+### Step 4: Create E2E test file
+- Read `.claude/commands/e2e/test_audit_extraction_fix.md` for reference
+- Create `.claude/commands/e2e/test_view_audit_pdf.md` that validates:
+  - User can navigate to supplier certification tab
+  - User can see "View Full PDF" button on a completed audit
+  - Clicking the button opens the PDF in a new tab (no console errors)
+  - The PDF content is displayed correctly
+
+### Step 5: Run validation commands
+- Execute all validation commands to ensure no regressions
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+```bash
+# Verify the new endpoint exists in audit_routes
+grep -q "download" apps/Server/app/api/audit_routes.py && echo "download endpoint found" || echo "download endpoint MISSING"
+
+# Run Server tests
+cd apps/Server && .venv/bin/pytest tests/api/test_audit_routes.py -v --tb=short
+
+# Run all Server tests
+cd apps/Server && .venv/bin/pytest tests/ -v --tb=short
+
+# Run Client type check
+cd apps/Client && npm run typecheck
+
+# Run Client build
+cd apps/Client && npm run build
+```
+
+After implementation, manually test:
+1. Start the application
+2. Navigate to Suppliers > Edit Supplier > Certification tab
+3. Click "View Full PDF" on an audit with a local file URL
+4. Verify PDF opens in new tab without console errors
+
+Read `.claude/commands/test_e2e.md`, then read and execute `.claude/commands/e2e/test_view_audit_pdf.md` to validate this functionality works.
+
+## Notes
+1. **Security**: The new endpoint must verify authentication and that the audit belongs to the requested supplier
+2. **Content-Disposition**: Use `inline` (not `attachment`) so the PDF opens in the browser rather than downloading
+3. **CORS**: The endpoint returns a file, so CORS shouldn't be an issue when using RedirectResponse for Supabase URLs
+4. **Backwards Compatibility**: This fix works for both old `file://` URLs and new Supabase Storage URLs
+5. **Temp File Cleanup**: Local temp files may get deleted on server restart; this is expected behavior for development. Production should always use Supabase Storage.


### PR DESCRIPTION
…PDFs

- Add /download endpoint to audit_routes.py that serves PDF files
- For file:// URLs, read and stream local file content
- For https:// URLs, redirect to Supabase Storage
- Update frontend to use backend download endpoint instead of direct URL
- Change onViewPdf callback to accept auditId instead of documentUrl