### PR TITLE
feat: add admin user management page with full CRUD

### DIFF
--- a/apps/Client/src/App.tsx
+++ b/apps/Client/src/App.tsx
@@ -18,6 +18,7 @@ import ImportWizardPage from './pages/kompass/ImportWizardPage';
 import NichesPage from './pages/kompass/NichesPage';
 import PricingConfigPage from './pages/kompass/PricingConfigPage';
 import DocumentationPage from './pages/kompass/DocumentationPage';
+import UsersPage from './pages/kompass/UsersPage';
 
 function App() {
   const { isLoading } = useAuth();
@@ -56,6 +57,7 @@ function App() {
                 <Route path="quotations/:id" element={<QuotationCreatorPage />} />
                 <Route path="niches" element={<NichesPage />} />
                 <Route path="pricing" element={<PricingConfigPage />} />
+                <Route path="users" element={<UsersPage />} />
                 <Route path="settings" element={<SettingsPage />} />
                 <Route path="docs" element={<DocumentationPage />} />
               </Routes>

--- a/apps/Client/src/components/kompass/UserForm.tsx
+++ b/apps/Client/src/components/kompass/UserForm.tsx
@@ -1,0 +1,481 @@
+import React, { useEffect, useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Box,
+  Alert,
+  CircularProgress,
+  MenuItem,
+  FormControlLabel,
+  Switch,
+  InputAdornment,
+  IconButton,
+} from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import type { UserAdminResponse, UserAdminCreate, UserAdminUpdate, UserRole } from '@/types/kompass';
+import { userService } from '@/services/kompassService';
+
+const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
+  { value: 'admin', label: 'Admin' },
+  { value: 'manager', label: 'Manager' },
+  { value: 'user', label: 'User' },
+  { value: 'viewer', label: 'Viewer' },
+];
+
+interface UserFormProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  user?: UserAdminResponse | null;
+  currentUserId?: string;
+}
+
+interface CreateFormData {
+  email: string;
+  password: string;
+  first_name: string;
+  last_name: string;
+  role: UserRole;
+}
+
+interface EditFormData {
+  first_name: string;
+  last_name: string;
+  role: UserRole;
+  is_active: boolean;
+}
+
+const UserForm: React.FC<UserFormProps> = ({ open, onClose, onSuccess, user, currentUserId }) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showPassword, setShowPassword] = useState(false);
+
+  // Password change state
+  const [passwordDialogOpen, setPasswordDialogOpen] = useState(false);
+  const [newPassword, setNewPassword] = useState('');
+  const [passwordLoading, setPasswordLoading] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+
+  const isEditMode = !!user;
+  const isSelf = user && currentUserId && user.id === currentUserId;
+
+  const createForm = useForm<CreateFormData>({
+    defaultValues: {
+      email: '',
+      password: '',
+      first_name: '',
+      last_name: '',
+      role: 'user',
+    },
+  });
+
+  const editForm = useForm<EditFormData>({
+    defaultValues: {
+      first_name: '',
+      last_name: '',
+      role: 'user',
+      is_active: true,
+    },
+  });
+
+  useEffect(() => {
+    if (open) {
+      setError(null);
+      setShowPassword(false);
+      if (user) {
+        editForm.reset({
+          first_name: user.first_name || '',
+          last_name: user.last_name || '',
+          role: user.role,
+          is_active: user.is_active,
+        });
+      } else {
+        createForm.reset({
+          email: '',
+          password: '',
+          first_name: '',
+          last_name: '',
+          role: 'user',
+        });
+      }
+    }
+  }, [open, user, createForm, editForm]);
+
+  const onCreateSubmit = async (data: CreateFormData) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const payload: UserAdminCreate = {
+        email: data.email,
+        password: data.password,
+        first_name: data.first_name || undefined,
+        last_name: data.last_name || undefined,
+        role: data.role,
+      };
+
+      console.log('INFO [UserForm]: Creating new user');
+      await userService.create(payload);
+      onSuccess();
+      onClose();
+    } catch (err) {
+      console.log('ERROR [UserForm]: Failed to create user', err);
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosErr = err as { response?: { data?: { detail?: string } } };
+        setError(axiosErr.response?.data?.detail || 'Failed to create user');
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to create user');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onEditSubmit = async (data: EditFormData) => {
+    if (!user) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const payload: UserAdminUpdate = {
+        first_name: data.first_name || undefined,
+        last_name: data.last_name || undefined,
+        role: data.role,
+        is_active: data.is_active,
+      };
+
+      console.log(`INFO [UserForm]: Updating user ${user.id}`);
+      await userService.update(user.id, payload);
+      onSuccess();
+      onClose();
+    } catch (err) {
+      console.log('ERROR [UserForm]: Failed to update user', err);
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosErr = err as { response?: { data?: { detail?: string } } };
+        setError(axiosErr.response?.data?.detail || 'Failed to update user');
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to update user');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleChangePassword = async () => {
+    if (!user || newPassword.length < 8) return;
+
+    setPasswordLoading(true);
+    setPasswordError(null);
+
+    try {
+      console.log(`INFO [UserForm]: Changing password for user ${user.id}`);
+      await userService.changePassword(user.id, { new_password: newPassword });
+      setPasswordDialogOpen(false);
+      setNewPassword('');
+    } catch (err) {
+      console.log('ERROR [UserForm]: Failed to change password', err);
+      setPasswordError(err instanceof Error ? err.message : 'Failed to change password');
+    } finally {
+      setPasswordLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!loading) {
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+        <DialogTitle>{isEditMode ? 'Edit User' : 'Add User'}</DialogTitle>
+
+        {/* CREATE FORM */}
+        {!isEditMode && (
+          <form onSubmit={createForm.handleSubmit(onCreateSubmit)}>
+            <DialogContent>
+              {error && (
+                <Alert severity="error" sx={{ mb: 2 }}>
+                  {error}
+                </Alert>
+              )}
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <TextField
+                  fullWidth
+                  label="Email"
+                  type="email"
+                  {...createForm.register('email', {
+                    required: 'Email is required',
+                    pattern: {
+                      value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                      message: 'Invalid email address',
+                    },
+                  })}
+                  error={!!createForm.formState.errors.email}
+                  helperText={createForm.formState.errors.email?.message}
+                  disabled={loading}
+                />
+                <TextField
+                  fullWidth
+                  label="Password"
+                  type={showPassword ? 'text' : 'password'}
+                  {...createForm.register('password', {
+                    required: 'Password is required',
+                    minLength: {
+                      value: 8,
+                      message: 'Password must be at least 8 characters',
+                    },
+                  })}
+                  error={!!createForm.formState.errors.password}
+                  helperText={createForm.formState.errors.password?.message}
+                  disabled={loading}
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          onClick={() => setShowPassword(!showPassword)}
+                          edge="end"
+                          size="small"
+                        >
+                          {showPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+                <TextField
+                  fullWidth
+                  label="First Name"
+                  {...createForm.register('first_name')}
+                  disabled={loading}
+                />
+                <TextField
+                  fullWidth
+                  label="Last Name"
+                  {...createForm.register('last_name')}
+                  disabled={loading}
+                />
+                <Controller
+                  name="role"
+                  control={createForm.control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      fullWidth
+                      select
+                      label="Role"
+                      disabled={loading}
+                    >
+                      {ROLE_OPTIONS.map((opt) => (
+                        <MenuItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  )}
+                />
+              </Box>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleClose} disabled={loading}>
+                Cancel
+              </Button>
+              <Box sx={{ position: 'relative' }}>
+                <Button type="submit" variant="contained" disabled={loading}>
+                  Create
+                </Button>
+                {loading && (
+                  <CircularProgress
+                    size={24}
+                    sx={{
+                      position: 'absolute',
+                      top: '50%',
+                      left: '50%',
+                      marginTop: '-12px',
+                      marginLeft: '-12px',
+                    }}
+                  />
+                )}
+              </Box>
+            </DialogActions>
+          </form>
+        )}
+
+        {/* EDIT FORM */}
+        {isEditMode && (
+          <form onSubmit={editForm.handleSubmit(onEditSubmit)}>
+            <DialogContent>
+              {error && (
+                <Alert severity="error" sx={{ mb: 2 }}>
+                  {error}
+                </Alert>
+              )}
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <TextField
+                  fullWidth
+                  label="Email"
+                  value={user?.email || ''}
+                  disabled
+                  helperText="Email cannot be changed"
+                />
+                <TextField
+                  fullWidth
+                  label="First Name"
+                  {...editForm.register('first_name')}
+                  disabled={loading}
+                />
+                <TextField
+                  fullWidth
+                  label="Last Name"
+                  {...editForm.register('last_name')}
+                  disabled={loading}
+                />
+                <Controller
+                  name="role"
+                  control={editForm.control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      fullWidth
+                      select
+                      label="Role"
+                      disabled={loading || !!isSelf}
+                      helperText={isSelf ? 'Cannot change your own role' : ''}
+                    >
+                      {ROLE_OPTIONS.map((opt) => (
+                        <MenuItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  )}
+                />
+                <Controller
+                  name="is_active"
+                  control={editForm.control}
+                  render={({ field }) => (
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={field.value}
+                          onChange={field.onChange}
+                          disabled={loading || !!isSelf}
+                        />
+                      }
+                      label="Active"
+                    />
+                  )}
+                />
+                {isSelf && (
+                  <Alert severity="info" variant="outlined">
+                    You cannot change your own role or deactivate your own account.
+                  </Alert>
+                )}
+                <Button
+                  variant="outlined"
+                  onClick={() => {
+                    setNewPassword('');
+                    setPasswordError(null);
+                    setShowNewPassword(false);
+                    setPasswordDialogOpen(true);
+                  }}
+                  disabled={loading}
+                >
+                  Change Password
+                </Button>
+              </Box>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleClose} disabled={loading}>
+                Cancel
+              </Button>
+              <Box sx={{ position: 'relative' }}>
+                <Button type="submit" variant="contained" disabled={loading}>
+                  Update
+                </Button>
+                {loading && (
+                  <CircularProgress
+                    size={24}
+                    sx={{
+                      position: 'absolute',
+                      top: '50%',
+                      left: '50%',
+                      marginTop: '-12px',
+                      marginLeft: '-12px',
+                    }}
+                  />
+                )}
+              </Box>
+            </DialogActions>
+          </form>
+        )}
+      </Dialog>
+
+      {/* Change Password Dialog */}
+      <Dialog
+        open={passwordDialogOpen}
+        onClose={() => !passwordLoading && setPasswordDialogOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Change Password</DialogTitle>
+        <DialogContent>
+          {passwordError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {passwordError}
+            </Alert>
+          )}
+          <TextField
+            fullWidth
+            label="New Password"
+            type={showNewPassword ? 'text' : 'password'}
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            disabled={passwordLoading}
+            helperText="Minimum 8 characters"
+            sx={{ mt: 1 }}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    onClick={() => setShowNewPassword(!showNewPassword)}
+                    edge="end"
+                    size="small"
+                  >
+                    {showNewPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setPasswordDialogOpen(false)}
+            disabled={passwordLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleChangePassword}
+            variant="contained"
+            disabled={passwordLoading || newPassword.length < 8}
+          >
+            {passwordLoading ? <CircularProgress size={20} /> : 'Change Password'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default UserForm;

--- a/apps/Client/src/components/layout/Sidebar.tsx
+++ b/apps/Client/src/components/layout/Sidebar.tsx
@@ -28,6 +28,7 @@ import DescriptionIcon from '@mui/icons-material/Description';
 import CategoryIcon from '@mui/icons-material/Category';
 import LabelIcon from '@mui/icons-material/Label';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -38,6 +39,7 @@ interface NavItem {
   title: string;
   icon: React.ReactElement;
   path: string;
+  adminOnly?: boolean;
 }
 
 const navItems: NavItem[] = [
@@ -51,6 +53,7 @@ const navItems: NavItem[] = [
   { title: 'Quotations', icon: <DescriptionIcon />, path: '/quotations' },
   { title: 'Niches', icon: <LabelIcon />, path: '/niches' },
   { title: 'Pricing', icon: <AttachMoneyIcon />, path: '/pricing' },
+  { title: 'Users', icon: <AdminPanelSettingsIcon />, path: '/users', adminOnly: true },
   { title: 'Settings', icon: <SettingsIcon />, path: '/settings' },
   { title: 'Help & Docs', icon: <HelpOutlineIcon />, path: '/docs' },
 ];
@@ -116,7 +119,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onToggle, width }
 
       {/* Navigation */}
       <List sx={{ flexGrow: 1, py: 2 }}>
-        {navItems.map((item) => {
+        {navItems.filter((item) => !item.adminOnly || user?.role === 'admin').map((item) => {
           const isActive = location.pathname === item.path;
 
           return (

--- a/apps/Client/src/pages/kompass/UsersPage.tsx
+++ b/apps/Client/src/pages/kompass/UsersPage.tsx
@@ -1,0 +1,379 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Alert,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  IconButton,
+  Chip,
+  TextField,
+  MenuItem,
+  TablePagination,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  InputAdornment,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import SearchIcon from '@mui/icons-material/Search';
+import type { UserAdminResponse, UserRole } from '@/types/kompass';
+import { userService } from '@/services/kompassService';
+import { useAuth } from '@/hooks/useAuth';
+import UserForm from '@/components/kompass/UserForm';
+import axios from 'axios';
+
+const ROLE_COLORS: Record<UserRole, 'error' | 'warning' | 'primary' | 'default'> = {
+  admin: 'error',
+  manager: 'warning',
+  user: 'primary',
+  viewer: 'default',
+};
+
+const UsersPage: React.FC = () => {
+  const { user: currentUser } = useAuth();
+
+  // Data state
+  const [users, setUsers] = useState<UserAdminResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [total, setTotal] = useState(0);
+
+  // Pagination
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(20);
+
+  // Filters
+  const [search, setSearch] = useState('');
+  const [roleFilter, setRoleFilter] = useState<string>('');
+  const [activeFilter, setActiveFilter] = useState<string>('');
+
+  // Dialog state
+  const [formOpen, setFormOpen] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<UserAdminResponse | null>(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [userToDelete, setUserToDelete] = useState<UserAdminResponse | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const fetchUsers = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      console.log('INFO [UsersPage]: Fetching users');
+      const filters: { search?: string; role?: string; is_active?: boolean } = {};
+      if (search) filters.search = search;
+      if (roleFilter) filters.role = roleFilter;
+      if (activeFilter !== '') filters.is_active = activeFilter === 'true';
+
+      const response = await userService.list(page + 1, rowsPerPage, filters);
+      setUsers(response.items);
+      setTotal(response.total);
+      console.log(`INFO [UsersPage]: Fetched ${response.items.length} users`);
+    } catch (err) {
+      console.log('ERROR [UsersPage]: Failed to fetch users', err);
+      setError(err instanceof Error ? err.message : 'Failed to load users');
+    } finally {
+      setLoading(false);
+    }
+  }, [page, rowsPerPage, search, roleFilter, activeFilter]);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  // Handlers
+  const handleAddClick = () => {
+    setSelectedUser(null);
+    setFormOpen(true);
+  };
+
+  const handleEditClick = (user: UserAdminResponse) => {
+    setSelectedUser(user);
+    setFormOpen(true);
+  };
+
+  const handleFormClose = () => {
+    setFormOpen(false);
+    setSelectedUser(null);
+  };
+
+  const handleFormSuccess = () => {
+    fetchUsers();
+  };
+
+  const handleDeleteClick = (user: UserAdminResponse) => {
+    setUserToDelete(user);
+    setDeleteError(null);
+    setDeleteDialogOpen(true);
+  };
+
+  const handleDeleteCancel = () => {
+    setDeleteDialogOpen(false);
+    setUserToDelete(null);
+    setDeleteError(null);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!userToDelete) return;
+
+    setDeleteLoading(true);
+    setDeleteError(null);
+
+    try {
+      console.log(`INFO [UsersPage]: Deleting user ${userToDelete.id}`);
+      await userService.delete(userToDelete.id);
+      setDeleteDialogOpen(false);
+      setUserToDelete(null);
+      fetchUsers();
+    } catch (err) {
+      console.log('ERROR [UsersPage]: Failed to delete user', err);
+      if (axios.isAxiosError(err) && err.response?.status === 409) {
+        setDeleteError(
+          err.response.data?.detail ||
+            'Cannot delete user because they have associated records. Consider deactivating instead.'
+        );
+      } else if (axios.isAxiosError(err) && err.response?.data?.detail) {
+        setDeleteError(err.response.data.detail);
+      } else {
+        setDeleteError(err instanceof Error ? err.message : 'Failed to delete user');
+      }
+    } finally {
+      setDeleteLoading(false);
+    }
+  };
+
+  const handleChangePage = (_: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  return (
+    <Box>
+      {/* Header */}
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
+        <Typography variant="h4">User Management</Typography>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={handleAddClick}>
+          Add User
+        </Button>
+      </Box>
+
+      {/* Error Alert */}
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {/* Filters */}
+      <Box display="flex" gap={2} mb={3} flexWrap="wrap">
+        <TextField
+          size="small"
+          placeholder="Search by email or name..."
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(0);
+          }}
+          sx={{ minWidth: 280 }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon />
+              </InputAdornment>
+            ),
+          }}
+        />
+        <TextField
+          size="small"
+          select
+          label="Role"
+          value={roleFilter}
+          onChange={(e) => {
+            setRoleFilter(e.target.value);
+            setPage(0);
+          }}
+          sx={{ minWidth: 140 }}
+        >
+          <MenuItem value="">All Roles</MenuItem>
+          <MenuItem value="admin">Admin</MenuItem>
+          <MenuItem value="manager">Manager</MenuItem>
+          <MenuItem value="user">User</MenuItem>
+          <MenuItem value="viewer">Viewer</MenuItem>
+        </TextField>
+        <TextField
+          size="small"
+          select
+          label="Status"
+          value={activeFilter}
+          onChange={(e) => {
+            setActiveFilter(e.target.value);
+            setPage(0);
+          }}
+          sx={{ minWidth: 140 }}
+        >
+          <MenuItem value="">All</MenuItem>
+          <MenuItem value="true">Active</MenuItem>
+          <MenuItem value="false">Inactive</MenuItem>
+        </TextField>
+      </Box>
+
+      {/* Loading State */}
+      {loading && (
+        <Box display="flex" justifyContent="center" py={4}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {/* Empty State */}
+      {!loading && users.length === 0 && (
+        <Box textAlign="center" py={4}>
+          <Typography color="text.secondary">
+            No users found. {search || roleFilter || activeFilter ? 'Try adjusting your filters.' : 'Click "Add User" to create one.'}
+          </Typography>
+        </Box>
+      )}
+
+      {/* Users Table */}
+      {!loading && users.length > 0 && (
+        <>
+          <TableContainer component={Paper} variant="outlined">
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Email</TableCell>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Role</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell>Created</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {users.map((u) => {
+                  const isSelf = currentUser?.id === u.id;
+                  const fullName = [u.first_name, u.last_name].filter(Boolean).join(' ') || '-';
+
+                  return (
+                    <TableRow key={u.id} hover>
+                      <TableCell>{u.email}</TableCell>
+                      <TableCell>{fullName}</TableCell>
+                      <TableCell>
+                        <Chip
+                          label={u.role.charAt(0).toUpperCase() + u.role.slice(1)}
+                          size="small"
+                          color={ROLE_COLORS[u.role]}
+                          variant="outlined"
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Chip
+                          label={u.is_active ? 'Active' : 'Inactive'}
+                          size="small"
+                          color={u.is_active ? 'success' : 'default'}
+                          variant={u.is_active ? 'filled' : 'outlined'}
+                        />
+                      </TableCell>
+                      <TableCell>{formatDate(u.created_at)}</TableCell>
+                      <TableCell align="right">
+                        <IconButton
+                          size="small"
+                          onClick={() => handleEditClick(u)}
+                          aria-label="edit"
+                        >
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          onClick={() => handleDeleteClick(u)}
+                          aria-label="delete"
+                          color="error"
+                          disabled={isSelf}
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <TablePagination
+            component="div"
+            count={total}
+            page={page}
+            onPageChange={handleChangePage}
+            rowsPerPage={rowsPerPage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+            rowsPerPageOptions={[10, 20, 50]}
+          />
+        </>
+      )}
+
+      {/* User Form Dialog */}
+      <UserForm
+        open={formOpen}
+        onClose={handleFormClose}
+        onSuccess={handleFormSuccess}
+        user={selectedUser}
+        currentUserId={currentUser?.id}
+      />
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={deleteDialogOpen} onClose={handleDeleteCancel}>
+        <DialogTitle>Delete User</DialogTitle>
+        <DialogContent>
+          {deleteError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {deleteError}
+            </Alert>
+          )}
+          <DialogContentText>
+            Are you sure you want to delete the user "{userToDelete?.email}"? This action cannot be
+            undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleDeleteCancel} disabled={deleteLoading}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleDeleteConfirm}
+            color="error"
+            variant="contained"
+            disabled={deleteLoading}
+          >
+            {deleteLoading ? <CircularProgress size={20} /> : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default UsersPage;

--- a/apps/Client/src/services/kompassService.ts
+++ b/apps/Client/src/services/kompassService.ts
@@ -5,6 +5,12 @@
 
 import apiClient from '@/api/clients';
 import type {
+  // User admin types
+  UserAdminCreate,
+  UserAdminUpdate,
+  UserAdminResponse,
+  UserListResponse,
+  UserChangePassword,
   // Niche types
   NicheCreate,
   NicheUpdate,
@@ -106,6 +112,52 @@ import type {
   SupplierAuditListResponse,
   ClassificationOverride,
 } from '@/types/kompass';
+
+// =============================================================================
+// USER ADMIN SERVICE
+// =============================================================================
+
+export const userService = {
+  async list(
+    page = 1,
+    limit = 20,
+    filters?: { search?: string; role?: string; is_active?: boolean }
+  ): Promise<UserListResponse> {
+    console.log('INFO [userService]: Fetching users list');
+    const response = await apiClient.get<UserListResponse>('/users', {
+      params: { page, limit, ...filters },
+    });
+    return response.data;
+  },
+
+  async get(id: string): Promise<UserAdminResponse> {
+    console.log(`INFO [userService]: Fetching user ${id}`);
+    const response = await apiClient.get<UserAdminResponse>(`/users/${id}`);
+    return response.data;
+  },
+
+  async create(data: UserAdminCreate): Promise<UserAdminResponse> {
+    console.log('INFO [userService]: Creating user');
+    const response = await apiClient.post<UserAdminResponse>('/users', data);
+    return response.data;
+  },
+
+  async update(id: string, data: UserAdminUpdate): Promise<UserAdminResponse> {
+    console.log(`INFO [userService]: Updating user ${id}`);
+    const response = await apiClient.put<UserAdminResponse>(`/users/${id}`, data);
+    return response.data;
+  },
+
+  async changePassword(id: string, data: UserChangePassword): Promise<void> {
+    console.log(`INFO [userService]: Changing password for user ${id}`);
+    await apiClient.put(`/users/${id}/password`, data);
+  },
+
+  async delete(id: string): Promise<void> {
+    console.log(`INFO [userService]: Deleting user ${id}`);
+    await apiClient.delete(`/users/${id}`);
+  },
+};
 
 // =============================================================================
 // NICHE SERVICE

--- a/apps/Client/src/types/kompass.ts
+++ b/apps/Client/src/types/kompass.ts
@@ -4,6 +4,50 @@
  */
 
 // =============================================================================
+// USER ADMIN DTOs
+// =============================================================================
+
+export type UserRole = 'admin' | 'manager' | 'user' | 'viewer';
+
+export interface UserAdminResponse {
+  id: string;
+  email: string;
+  first_name: string | null;
+  last_name: string | null;
+  role: UserRole;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UserAdminCreate {
+  email: string;
+  password: string;
+  first_name?: string;
+  last_name?: string;
+  role: UserRole;
+}
+
+export interface UserAdminUpdate {
+  first_name?: string;
+  last_name?: string;
+  role?: UserRole;
+  is_active?: boolean;
+}
+
+export interface UserListResponse {
+  items: UserAdminResponse[];
+  total: number;
+  page: number;
+  limit: number;
+  pages: number;
+}
+
+export interface UserChangePassword {
+  new_password: string;
+}
+
+// =============================================================================
 // ENUMS / STATUS TYPES
 // =============================================================================
 

--- a/apps/Server/app/api/user_routes.py
+++ b/apps/Server/app/api/user_routes.py
@@ -1,0 +1,216 @@
+"""User management API routes (admin only)."""
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.api.rbac_dependencies import require_roles
+from app.models.auth_dto import (
+    UserAdminCreateDTO,
+    UserAdminResponseDTO,
+    UserAdminUpdateDTO,
+    UserChangePasswordDTO,
+    UserListResponseDTO,
+)
+from app.services.user_service import user_service
+
+router = APIRouter(tags=["Users"])
+
+
+@router.get("/", response_model=UserListResponseDTO)
+async def list_users(
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+    search: Optional[str] = Query(None),
+    role: Optional[str] = Query(None),
+    is_active: Optional[bool] = Query(None),
+    current_user: dict = Depends(require_roles(["admin"])),
+) -> UserListResponseDTO:
+    """List all users with pagination and filters.
+
+    Args:
+        page: Page number
+        limit: Items per page
+        search: Search by email or name
+        role: Filter by role
+        is_active: Filter by active status
+
+    Returns:
+        Paginated user list
+    """
+    print(f"INFO [UserRoutes]: Listing users page={page}")
+    return user_service.list_users(
+        page=page, limit=limit, search=search, role=role, is_active=is_active
+    )
+
+
+@router.get("/{user_id}", response_model=UserAdminResponseDTO)
+async def get_user(
+    user_id: UUID,
+    current_user: dict = Depends(require_roles(["admin"])),
+) -> UserAdminResponseDTO:
+    """Get a single user by ID.
+
+    Args:
+        user_id: UUID of the user
+
+    Returns:
+        User details
+
+    Raises:
+        HTTPException 404: If user not found
+    """
+    print(f"INFO [UserRoutes]: Getting user {user_id}")
+    result = user_service.get_user(user_id)
+    if not result:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+    return result
+
+
+@router.post("/", response_model=UserAdminResponseDTO, status_code=status.HTTP_201_CREATED)
+async def create_user(
+    data: UserAdminCreateDTO,
+    current_user: dict = Depends(require_roles(["admin"])),
+) -> UserAdminResponseDTO:
+    """Create a new user.
+
+    Args:
+        data: User creation data (email, password, role, etc.)
+
+    Returns:
+        Created user
+
+    Raises:
+        HTTPException 400: If creation fails (e.g., duplicate email)
+    """
+    print(f"INFO [UserRoutes]: Creating user {data.email}")
+    result = user_service.create_user(data)
+    if not result:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to create user. Email may already exist.",
+        )
+    return result
+
+
+@router.put("/{user_id}", response_model=UserAdminResponseDTO)
+async def update_user(
+    user_id: UUID,
+    data: UserAdminUpdateDTO,
+    current_user: dict = Depends(require_roles(["admin"])),
+) -> UserAdminResponseDTO:
+    """Update a user's details.
+
+    Args:
+        user_id: UUID of the user to update
+        data: Update data (name, role, is_active)
+
+    Returns:
+        Updated user
+
+    Raises:
+        HTTPException 404: If user not found
+        HTTPException 400: If update fails or self-protection triggered
+    """
+    print(f"INFO [UserRoutes]: Updating user {user_id}")
+
+    existing = user_service.get_user(user_id)
+    if not existing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    try:
+        result = user_service.update_user(user_id, data, current_user["id"])
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+    if not result:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to update user.",
+        )
+    return result
+
+
+@router.put("/{user_id}/password")
+async def change_password(
+    user_id: UUID,
+    data: UserChangePasswordDTO,
+    current_user: dict = Depends(require_roles(["admin"])),
+) -> dict:
+    """Change a user's password.
+
+    Args:
+        user_id: UUID of the user
+        data: New password
+
+    Returns:
+        Success message
+
+    Raises:
+        HTTPException 404: If user not found
+        HTTPException 400: If password change fails
+    """
+    print(f"INFO [UserRoutes]: Changing password for user {user_id}")
+
+    existing = user_service.get_user(user_id)
+    if not existing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    success = user_service.change_password(user_id, data)
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to change password.",
+        )
+    return {"message": "Password changed successfully"}
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_user(
+    user_id: UUID,
+    current_user: dict = Depends(require_roles(["admin"])),
+) -> None:
+    """Delete a user.
+
+    Args:
+        user_id: UUID of the user to delete
+
+    Raises:
+        HTTPException 404: If user not found
+        HTTPException 400: If self-deletion attempted
+        HTTPException 409: If user has FK references
+    """
+    print(f"INFO [UserRoutes]: Deleting user {user_id}")
+
+    existing = user_service.get_user(user_id)
+    if not existing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    try:
+        success = user_service.delete_user(user_id, current_user["id"])
+        if not success:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Failed to delete user.",
+            )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(e),
+        )

--- a/apps/Server/app/models/auth_dto.py
+++ b/apps/Server/app/models/auth_dto.py
@@ -1,8 +1,9 @@
 """Authentication Data Transfer Objects (DTOs)."""
 
-from typing import Optional
+from datetime import datetime
+from typing import List, Literal, Optional
 from uuid import UUID
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 
 
 class UserRegisterDTO(BaseModel):
@@ -40,3 +41,58 @@ class TokenResponseDTO(BaseModel):
     access_token: str
     token_type: str = "bearer"
     user: UserResponseDTO
+
+
+# =============================================================================
+# ADMIN USER MANAGEMENT DTOs
+# =============================================================================
+
+
+class UserAdminCreateDTO(BaseModel):
+    """Request model for admin user creation."""
+
+    email: EmailStr
+    password: str = Field(..., min_length=8)
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    role: Literal["admin", "manager", "user", "viewer"] = "user"
+
+
+class UserAdminUpdateDTO(BaseModel):
+    """Request model for admin user update."""
+
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    role: Optional[Literal["admin", "manager", "user", "viewer"]] = None
+    is_active: Optional[bool] = None
+
+
+class UserAdminResponseDTO(BaseModel):
+    """Response model for admin user management (includes timestamps)."""
+
+    id: UUID
+    email: str
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    role: str
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class UserListResponseDTO(BaseModel):
+    """Paginated list of users."""
+
+    items: List[UserAdminResponseDTO]
+    total: int
+    page: int
+    limit: int
+    pages: int
+
+
+class UserChangePasswordDTO(BaseModel):
+    """Request model for admin password change."""
+
+    new_password: str = Field(..., min_length=8)

--- a/apps/Server/app/repository/user_repository.py
+++ b/apps/Server/app/repository/user_repository.py
@@ -147,6 +147,316 @@ class UserRepository:
         finally:
             close_database_connection(conn)
 
+    def get_user_by_id_full(self, user_id: UUID) -> Optional[Dict[str, Any]]:
+        """Get user by UUID including timestamps.
+
+        Args:
+            user_id: User UUID
+
+        Returns:
+            User dict with timestamps if found, None otherwise
+        """
+        conn = get_database_connection()
+        if not conn:
+            return None
+
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id, email, first_name, last_name, role, is_active,
+                           created_at, updated_at
+                    FROM users
+                    WHERE id = %s
+                    """,
+                    (str(user_id),),
+                )
+                row = cur.fetchone()
+
+                if row:
+                    return {
+                        "id": row[0],
+                        "email": row[1],
+                        "first_name": row[2],
+                        "last_name": row[3],
+                        "role": row[4],
+                        "is_active": row[5],
+                        "created_at": row[6],
+                        "updated_at": row[7],
+                    }
+                return None
+        except Exception as e:
+            print(f"ERROR [UserRepository]: Failed to get user by id (full): {e}")
+            return None
+        finally:
+            close_database_connection(conn)
+
+    def list_users(
+        self,
+        page: int = 1,
+        limit: int = 20,
+        search: Optional[str] = None,
+        role: Optional[str] = None,
+        is_active: Optional[bool] = None,
+    ) -> list:
+        """List users with pagination and optional filters.
+
+        Args:
+            page: Page number (1-based)
+            limit: Items per page
+            search: Search term for email/name
+            role: Filter by role
+            is_active: Filter by active status
+
+        Returns:
+            List of user dicts
+        """
+        conn = get_database_connection()
+        if not conn:
+            return []
+
+        try:
+            with conn.cursor() as cur:
+                conditions = []
+                params: list = []
+
+                if search:
+                    conditions.append(
+                        "(email ILIKE %s OR first_name ILIKE %s OR last_name ILIKE %s)"
+                    )
+                    search_param = f"%{search}%"
+                    params.extend([search_param, search_param, search_param])
+
+                if role:
+                    conditions.append("role = %s")
+                    params.append(role)
+
+                if is_active is not None:
+                    conditions.append("is_active = %s")
+                    params.append(is_active)
+
+                where_clause = ""
+                if conditions:
+                    where_clause = "WHERE " + " AND ".join(conditions)
+
+                offset = (page - 1) * limit
+                params.extend([limit, offset])
+
+                cur.execute(
+                    f"""
+                    SELECT id, email, first_name, last_name, role, is_active,
+                           created_at, updated_at
+                    FROM users
+                    {where_clause}
+                    ORDER BY created_at DESC
+                    LIMIT %s OFFSET %s
+                    """,
+                    params,
+                )
+                rows = cur.fetchall()
+
+                return [
+                    {
+                        "id": row[0],
+                        "email": row[1],
+                        "first_name": row[2],
+                        "last_name": row[3],
+                        "role": row[4],
+                        "is_active": row[5],
+                        "created_at": row[6],
+                        "updated_at": row[7],
+                    }
+                    for row in rows
+                ]
+        except Exception as e:
+            print(f"ERROR [UserRepository]: Failed to list users: {e}")
+            return []
+        finally:
+            close_database_connection(conn)
+
+    def count_users(
+        self,
+        search: Optional[str] = None,
+        role: Optional[str] = None,
+        is_active: Optional[bool] = None,
+    ) -> int:
+        """Count users with optional filters.
+
+        Args:
+            search: Search term for email/name
+            role: Filter by role
+            is_active: Filter by active status
+
+        Returns:
+            Total count of matching users
+        """
+        conn = get_database_connection()
+        if not conn:
+            return 0
+
+        try:
+            with conn.cursor() as cur:
+                conditions = []
+                params: list = []
+
+                if search:
+                    conditions.append(
+                        "(email ILIKE %s OR first_name ILIKE %s OR last_name ILIKE %s)"
+                    )
+                    search_param = f"%{search}%"
+                    params.extend([search_param, search_param, search_param])
+
+                if role:
+                    conditions.append("role = %s")
+                    params.append(role)
+
+                if is_active is not None:
+                    conditions.append("is_active = %s")
+                    params.append(is_active)
+
+                where_clause = ""
+                if conditions:
+                    where_clause = "WHERE " + " AND ".join(conditions)
+
+                cur.execute(
+                    f"""
+                    SELECT COUNT(*) FROM users {where_clause}
+                    """,
+                    params or None,
+                )
+                row = cur.fetchone()
+                return row[0] if row else 0
+        except Exception as e:
+            print(f"ERROR [UserRepository]: Failed to count users: {e}")
+            return 0
+        finally:
+            close_database_connection(conn)
+
+    def update_user(self, user_id: UUID, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Update user fields.
+
+        Args:
+            user_id: User UUID
+            data: Dict of fields to update (first_name, last_name, role, is_active)
+
+        Returns:
+            Updated user dict or None if failed
+        """
+        conn = get_database_connection()
+        if not conn:
+            return None
+
+        try:
+            set_parts = []
+            params: list = []
+            for key, value in data.items():
+                if key in ("first_name", "last_name", "role", "is_active"):
+                    set_parts.append(f"{key} = %s")
+                    params.append(value)
+
+            if not set_parts:
+                return self.get_user_by_id_full(user_id)
+
+            set_parts.append("updated_at = NOW()")
+            params.append(str(user_id))
+
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    UPDATE users
+                    SET {', '.join(set_parts)}
+                    WHERE id = %s
+                    RETURNING id, email, first_name, last_name, role, is_active,
+                              created_at, updated_at
+                    """,
+                    params,
+                )
+                conn.commit()
+                row = cur.fetchone()
+
+                if row:
+                    return {
+                        "id": row[0],
+                        "email": row[1],
+                        "first_name": row[2],
+                        "last_name": row[3],
+                        "role": row[4],
+                        "is_active": row[5],
+                        "created_at": row[6],
+                        "updated_at": row[7],
+                    }
+                return None
+        except Exception as e:
+            print(f"ERROR [UserRepository]: Failed to update user: {e}")
+            conn.rollback()
+            return None
+        finally:
+            close_database_connection(conn)
+
+    def update_password(self, user_id: UUID, password_hash: str) -> bool:
+        """Update user password hash.
+
+        Args:
+            user_id: User UUID
+            password_hash: New bcrypt hash
+
+        Returns:
+            True if updated, False otherwise
+        """
+        conn = get_database_connection()
+        if not conn:
+            return False
+
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE users
+                    SET password_hash = %s, updated_at = NOW()
+                    WHERE id = %s
+                    """,
+                    (password_hash, str(user_id)),
+                )
+                conn.commit()
+                return cur.rowcount > 0
+        except Exception as e:
+            print(f"ERROR [UserRepository]: Failed to update password: {e}")
+            conn.rollback()
+            return False
+        finally:
+            close_database_connection(conn)
+
+    def delete_user(self, user_id: UUID) -> bool:
+        """Delete a user (hard delete).
+
+        Args:
+            user_id: User UUID
+
+        Returns:
+            True if deleted, False otherwise
+
+        Raises:
+            Exception: If FK constraints prevent deletion
+        """
+        conn = get_database_connection()
+        if not conn:
+            return False
+
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM users WHERE id = %s",
+                    (str(user_id),),
+                )
+                conn.commit()
+                return cur.rowcount > 0
+        except Exception as e:
+            print(f"ERROR [UserRepository]: Failed to delete user: {e}")
+            conn.rollback()
+            raise
+        finally:
+            close_database_connection(conn)
+
 
 # Singleton instance
 user_repository = UserRepository()

--- a/apps/Server/app/services/user_service.py
+++ b/apps/Server/app/services/user_service.py
@@ -1,0 +1,183 @@
+"""User management service for admin operations."""
+
+import math
+from typing import Optional
+from uuid import UUID
+
+from app.models.auth_dto import (
+    UserAdminCreateDTO,
+    UserAdminResponseDTO,
+    UserAdminUpdateDTO,
+    UserChangePasswordDTO,
+    UserListResponseDTO,
+)
+from app.repository.user_repository import user_repository
+from app.services.auth_service import auth_service
+
+
+class UserService:
+    """Business logic for admin user management."""
+
+    def list_users(
+        self,
+        page: int = 1,
+        limit: int = 20,
+        search: Optional[str] = None,
+        role: Optional[str] = None,
+        is_active: Optional[bool] = None,
+    ) -> UserListResponseDTO:
+        """List users with pagination and filters.
+
+        Args:
+            page: Page number (1-based)
+            limit: Items per page
+            search: Search term for email/name
+            role: Filter by role
+            is_active: Filter by active status
+
+        Returns:
+            Paginated user list response
+        """
+        print(f"INFO [UserService]: Listing users page={page} limit={limit}")
+        total = user_repository.count_users(search=search, role=role, is_active=is_active)
+        rows = user_repository.list_users(
+            page=page, limit=limit, search=search, role=role, is_active=is_active
+        )
+        items = [UserAdminResponseDTO(**row) for row in rows]
+        pages = math.ceil(total / limit) if limit > 0 else 0
+
+        return UserListResponseDTO(
+            items=items,
+            total=total,
+            page=page,
+            limit=limit,
+            pages=pages,
+        )
+
+    def get_user(self, user_id: UUID) -> Optional[UserAdminResponseDTO]:
+        """Get a single user by ID.
+
+        Args:
+            user_id: User UUID
+
+        Returns:
+            User response or None
+        """
+        print(f"INFO [UserService]: Getting user {user_id}")
+        row = user_repository.get_user_by_id_full(user_id)
+        if not row:
+            return None
+        return UserAdminResponseDTO(**row)
+
+    def create_user(self, data: UserAdminCreateDTO) -> Optional[UserAdminResponseDTO]:
+        """Create a new user with admin-specified role.
+
+        Args:
+            data: User creation data
+
+        Returns:
+            Created user response or None
+        """
+        print(f"INFO [UserService]: Creating user {data.email} with role {data.role}")
+
+        # Check for existing email
+        existing = user_repository.get_user_by_email(data.email)
+        if existing:
+            print(f"WARN [UserService]: Email already exists: {data.email}")
+            return None
+
+        password_hash = auth_service.hash_password(data.password)
+        result = user_repository.create_user(
+            email=data.email,
+            password_hash=password_hash,
+            first_name=data.first_name,
+            last_name=data.last_name,
+            role=data.role,
+        )
+        if not result:
+            return None
+
+        # Fetch the full user with timestamps
+        return self.get_user(result["id"])
+
+    def update_user(
+        self, user_id: UUID, data: UserAdminUpdateDTO, current_user_id: UUID
+    ) -> Optional[UserAdminResponseDTO]:
+        """Update user fields.
+
+        Args:
+            user_id: User UUID to update
+            data: Update data
+            current_user_id: ID of the admin performing the update
+
+        Returns:
+            Updated user response or None
+
+        Raises:
+            ValueError: If admin tries to deactivate themselves
+        """
+        print(f"INFO [UserService]: Updating user {user_id}")
+
+        # Self-protection: prevent admin from deactivating themselves
+        if str(user_id) == str(current_user_id) and data.is_active is False:
+            raise ValueError("Cannot deactivate your own account")
+
+        # Self-protection: prevent admin from changing their own role
+        if str(user_id) == str(current_user_id) and data.role is not None:
+            raise ValueError("Cannot change your own role")
+
+        update_data = data.model_dump(exclude_none=True)
+        if not update_data:
+            return self.get_user(user_id)
+
+        result = user_repository.update_user(user_id, update_data)
+        if not result:
+            return None
+        return UserAdminResponseDTO(**result)
+
+    def change_password(self, user_id: UUID, data: UserChangePasswordDTO) -> bool:
+        """Change a user's password.
+
+        Args:
+            user_id: User UUID
+            data: New password data
+
+        Returns:
+            True if password changed
+        """
+        print(f"INFO [UserService]: Changing password for user {user_id}")
+        password_hash = auth_service.hash_password(data.new_password)
+        return user_repository.update_password(user_id, password_hash)
+
+    def delete_user(self, user_id: UUID, current_user_id: UUID) -> bool:
+        """Delete a user.
+
+        Args:
+            user_id: User UUID to delete
+            current_user_id: ID of the admin performing the delete
+
+        Returns:
+            True if deleted
+
+        Raises:
+            ValueError: If admin tries to delete themselves or FK constraint fails
+        """
+        print(f"INFO [UserService]: Deleting user {user_id}")
+
+        if str(user_id) == str(current_user_id):
+            raise ValueError("Cannot delete your own account")
+
+        try:
+            return user_repository.delete_user(user_id)
+        except Exception as e:
+            error_msg = str(e).lower()
+            if "foreign key" in error_msg or "violates" in error_msg:
+                raise ValueError(
+                    "Cannot delete user because they have associated records. "
+                    "Consider deactivating them instead."
+                ) from e
+            raise
+
+
+# Singleton instance
+user_service = UserService()

--- a/apps/Server/main.py
+++ b/apps/Server/main.py
@@ -22,6 +22,7 @@ from app.api.quotation_routes import router as quotation_router
 from app.api.pricing_routes import router as pricing_router
 from app.api.dashboard_routes import router as dashboard_router
 from app.api.audit_routes import router as audit_router
+from app.api.user_routes import router as user_router
 from database.init_db import init_database
 
 
@@ -84,6 +85,7 @@ def create_app() -> FastAPI:
     app.include_router(pricing_router, prefix="/api/pricing")
     app.include_router(dashboard_router, prefix="/api/dashboard")
     app.include_router(audit_router, prefix="/api/suppliers")
+    app.include_router(user_router, prefix="/api/users")
 
     print(f"INFO [Main]: Application configured with CORS origins: {settings.get_cors_origins()}")
 


### PR DESCRIPTION
Add a new admin-only User Management page allowing admins to create, edit, deactivate, change passwords, and delete users through the UI.

Backend: admin DTOs, repository methods (list/update/delete), user service with self-protection, admin-only CRUD routes at /api/users. Frontend: UsersPage with table view, filters, pagination, UserForm dialog, sidebar nav visible only to admin role.