### PR TITLE
bug: fix mixed content HTTPS errors from backend 307 redirects

### DIFF
--- a/.claude/commands/e2e/test_mixed_content_https.md
+++ b/.claude/commands/e2e/test_mixed_content_https.md
@@ -1,0 +1,92 @@
+# E2E Test: Mixed Content HTTPS Validation
+
+## Test Name
+Mixed Content HTTPS Validation
+
+## User Story
+
+As a user accessing the application over HTTPS in production
+I want all API requests to use HTTPS consistently
+So that no mixed content errors block page data from loading
+
+## Prerequisites
+- Application running at configured URL
+- User authenticated with admin or manager role
+- Backend API available at /api
+
+## Test Steps
+
+### Step 1: Navigate to Portfolios Page
+1. Open the application at the base URL
+2. Login with admin test credentials (if required)
+3. Navigate to the Portfolios page via the sidebar navigation or direct URL `/portfolios`
+4. **Verify** the page loads with the title "Portfolios" visible
+5. **Verify** no error alert or snackbar is displayed on the page
+6. **Verify** either portfolio cards render with data OR the empty state message is displayed
+7. **Screenshot**: `01_portfolios_page_loaded.png`
+
+### Step 2: Verify Portfolios API Requests Succeed
+1. Check the browser console for any error messages
+2. **Verify** no "Network Error" messages appear in the console
+3. **Verify** no "Mixed Content" errors appear in the console
+4. **Verify** API requests to `/api/portfolios` return successful responses (status 200)
+5. **Screenshot**: `02_portfolios_no_errors.png`
+
+### Step 3: Navigate to Niches Page
+1. Navigate to the Niches page via the sidebar navigation or direct URL `/niches`
+2. **Verify** the page loads with the title "Niches" visible
+3. **Verify** no error alert or snackbar is displayed on the page
+4. **Verify** either niche items render with data OR the empty state message is displayed
+5. **Screenshot**: `03_niches_page_loaded.png`
+
+### Step 4: Verify Niches API Requests Succeed
+1. Check the browser console for any error messages
+2. **Verify** no "Network Error" messages appear in the console
+3. **Verify** no "Mixed Content" errors appear in the console
+4. **Verify** API requests to `/api/niches` return successful responses (status 200)
+5. **Screenshot**: `04_niches_no_errors.png`
+
+### Step 5: Verify No Console Errors Across Both Pages
+1. Navigate back to the Portfolios page `/portfolios`
+2. **Verify** the page loads successfully without errors
+3. Check the browser console for any accumulated error messages
+4. **Verify** no "Mixed Content" warnings appear in the console across both page navigations
+5. **Verify** no "Network Error" messages appear in the console
+6. **Screenshot**: `05_no_console_errors.png`
+
+## Success Criteria
+
+- [ ] Portfolios page loads with proper layout and data (or empty state)
+- [ ] No "Network Error" messages in the browser console on Portfolios page
+- [ ] No "Mixed Content" errors in the browser console on Portfolios page
+- [ ] Niches page loads with proper layout and data (or empty state)
+- [ ] No "Network Error" messages in the browser console on Niches page
+- [ ] No "Mixed Content" errors in the browser console on Niches page
+- [ ] API requests to `/api/portfolios` succeed (status 200)
+- [ ] API requests to `/api/niches` succeed (status 200)
+
+## Notes
+
+- This test validates the fix for the mixed content HTTPS error caused by FastAPI 307 redirects using `http://` in the Location header behind Render's TLS-terminating proxy
+- The fix includes: (1) adding `--proxy-headers --forwarded-allow-ips='*'` to uvicorn, (2) standardizing route trailing slashes to `""`, and (3) removing trailing slashes from frontend API calls
+- In local development (same origin, HTTP), the test verifies pages load and data is displayed without errors
+- In production (HTTPS), the proxy-headers fix ensures 307 redirect Location headers use `https://`
+
+## Output Format
+
+```json
+{
+  "test_name": "Mixed Content HTTPS Validation",
+  "status": "passed|failed",
+  "steps_completed": 5,
+  "steps_failed": [],
+  "screenshots": [
+    "01_portfolios_page_loaded.png",
+    "02_portfolios_no_errors.png",
+    "03_niches_page_loaded.png",
+    "04_niches_no_errors.png",
+    "05_no_console_errors.png"
+  ],
+  "error": null
+}
+```

--- a/apps/Client/src/services/kompassService.ts
+++ b/apps/Client/src/services/kompassService.ts
@@ -124,7 +124,7 @@ export const userService = {
     filters?: { search?: string; role?: string; is_active?: boolean }
   ): Promise<UserListResponse> {
     console.log('INFO [userService]: Fetching users list');
-    const response = await apiClient.get<UserListResponse>('/users/', {
+    const response = await apiClient.get<UserListResponse>('/users', {
       params: { page, limit, ...filters },
     });
     return response.data;
@@ -138,7 +138,7 @@ export const userService = {
 
   async create(data: UserAdminCreate): Promise<UserAdminResponse> {
     console.log('INFO [userService]: Creating user');
-    const response = await apiClient.post<UserAdminResponse>('/users/', data);
+    const response = await apiClient.post<UserAdminResponse>('/users', data);
     return response.data;
   },
 
@@ -166,7 +166,7 @@ export const userService = {
 export const nicheService = {
   async list(page = 1, limit = 20): Promise<NicheListResponse> {
     console.log('INFO [nicheService]: Fetching niches list');
-    const response = await apiClient.get<NicheListResponse>('/niches/', {
+    const response = await apiClient.get<NicheListResponse>('/niches', {
       params: { page, limit },
     });
     return response.data;
@@ -180,7 +180,7 @@ export const nicheService = {
 
   async create(data: NicheCreate): Promise<NicheResponse> {
     console.log('INFO [nicheService]: Creating niche');
-    const response = await apiClient.post<NicheResponse>('/niches/', data);
+    const response = await apiClient.post<NicheResponse>('/niches', data);
     return response.data;
   },
 
@@ -390,7 +390,7 @@ export const productService = {
 export const categoryService = {
   async list(page = 1, limit = 20): Promise<CategoryListResponse> {
     console.log('INFO [categoryService]: Fetching categories list');
-    const response = await apiClient.get<CategoryListResponse>('/categories/', {
+    const response = await apiClient.get<CategoryListResponse>('/categories', {
       params: { page, limit },
     });
     return response.data;
@@ -398,7 +398,7 @@ export const categoryService = {
 
   async getTree(): Promise<CategoryTreeNode[]> {
     console.log('INFO [categoryService]: Fetching category tree');
-    const response = await apiClient.get<CategoryTreeNode[]>('/categories/');
+    const response = await apiClient.get<CategoryTreeNode[]>('/categories');
     return response.data;
   },
 
@@ -410,7 +410,7 @@ export const categoryService = {
 
   async create(data: CategoryCreate): Promise<CategoryResponse> {
     console.log('INFO [categoryService]: Creating category');
-    const response = await apiClient.post<CategoryResponse>('/categories/', data);
+    const response = await apiClient.post<CategoryResponse>('/categories', data);
     return response.data;
   },
 
@@ -441,7 +441,7 @@ export const categoryService = {
 export const tagService = {
   async list(page = 1, limit = 20): Promise<TagListResponse> {
     console.log('INFO [tagService]: Fetching tags list');
-    const response = await apiClient.get<TagListResponse>('/tags/', {
+    const response = await apiClient.get<TagListResponse>('/tags', {
       params: { page, limit },
     });
     return response.data;
@@ -455,7 +455,7 @@ export const tagService = {
 
   async create(data: TagCreate): Promise<TagResponse> {
     console.log('INFO [tagService]: Creating tag');
-    const response = await apiClient.post<TagResponse>('/tags/', data);
+    const response = await apiClient.post<TagResponse>('/tags', data);
     return response.data;
   },
 
@@ -490,7 +490,7 @@ export const portfolioService = {
     filters?: PortfolioFilter
   ): Promise<PortfolioListResponse> {
     console.log('INFO [portfolioService]: Fetching portfolios list');
-    const response = await apiClient.get<PortfolioListResponse>('/portfolios/', {
+    const response = await apiClient.get<PortfolioListResponse>('/portfolios', {
       params: { page, limit, ...filters },
     });
     return response.data;
@@ -504,7 +504,7 @@ export const portfolioService = {
 
   async create(data: PortfolioCreate): Promise<PortfolioResponse> {
     console.log('INFO [portfolioService]: Creating portfolio');
-    const response = await apiClient.post<PortfolioResponse>('/portfolios/', data);
+    const response = await apiClient.post<PortfolioResponse>('/portfolios', data);
     return response.data;
   },
 

--- a/apps/Server/Dockerfile
+++ b/apps/Server/Dockerfile
@@ -19,4 +19,4 @@ COPY . .
 EXPOSE 8000
 
 # Run the application
-CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000} --proxy-headers --forwarded-allow-ips='*'"]

--- a/apps/Server/app/api/category_routes.py
+++ b/apps/Server/app/api/category_routes.py
@@ -25,7 +25,7 @@ class CategoryMoveDTO(BaseModel):
     new_parent_id: Optional[UUID] = None
 
 
-@router.get("/", response_model=List[CategoryTreeNode])
+@router.get("", response_model=List[CategoryTreeNode])
 async def list_categories(
     current_user: dict = Depends(get_current_user),
 ) -> List[CategoryTreeNode]:
@@ -38,7 +38,7 @@ async def list_categories(
     return category_service.list_categories()
 
 
-@router.post("/", response_model=CategoryResponseDTO, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=CategoryResponseDTO, status_code=status.HTTP_201_CREATED)
 async def create_category(
     data: CategoryCreateDTO,
     current_user: dict = Depends(get_current_user),

--- a/apps/Server/app/api/niche_routes.py
+++ b/apps/Server/app/api/niche_routes.py
@@ -18,7 +18,7 @@ from app.services.niche_service import niche_service
 router = APIRouter(tags=["Niches"])
 
 
-@router.get("/", response_model=List[NicheWithClientCountDTO])
+@router.get("", response_model=List[NicheWithClientCountDTO])
 async def list_niches(
     current_user: dict = Depends(get_current_user),
 ) -> List[NicheWithClientCountDTO]:
@@ -31,7 +31,7 @@ async def list_niches(
     return niche_service.list_niches()
 
 
-@router.post("/", response_model=NicheResponseDTO, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=NicheResponseDTO, status_code=status.HTTP_201_CREATED)
 async def create_niche(
     data: NicheCreateDTO,
     current_user: dict = Depends(get_current_user),

--- a/apps/Server/app/api/tag_routes.py
+++ b/apps/Server/app/api/tag_routes.py
@@ -19,7 +19,7 @@ from app.services.tag_service import tag_service
 router = APIRouter(tags=["Tags"])
 
 
-@router.get("/", response_model=TagListResponseDTO)
+@router.get("", response_model=TagListResponseDTO)
 async def list_tags(
     page: int = Query(1, ge=1, description="Page number"),
     limit: int = Query(20, ge=1, le=100, description="Items per page"),
@@ -58,7 +58,7 @@ async def search_tags(
     return tag_service.search_tags(query, limit)
 
 
-@router.post("/", response_model=TagResponseDTO, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=TagResponseDTO, status_code=status.HTTP_201_CREATED)
 async def create_tag(
     data: TagCreateDTO,
     current_user: dict = Depends(get_current_user),

--- a/apps/Server/app/api/user_routes.py
+++ b/apps/Server/app/api/user_routes.py
@@ -18,7 +18,7 @@ from app.services.user_service import user_service
 router = APIRouter(tags=["Users"])
 
 
-@router.get("/", response_model=UserListResponseDTO)
+@router.get("", response_model=UserListResponseDTO)
 async def list_users(
     page: int = Query(1, ge=1),
     limit: int = Query(20, ge=1, le=100),
@@ -71,7 +71,7 @@ async def get_user(
     return result
 
 
-@router.post("/", response_model=UserAdminResponseDTO, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=UserAdminResponseDTO, status_code=status.HTTP_201_CREATED)
 async def create_user(
     data: UserAdminCreateDTO,
     current_user: dict = Depends(require_roles(["admin"])),


### PR DESCRIPTION
Add --proxy-headers --forwarded-allow-ips='*' to uvicorn in Dockerfile so it trusts Render's X-Forwarded-Proto header, ensuring 307 redirect Location headers use https:// instead of http://. Standardize all backend route trailing slashes to "" and remove trailing slashes from frontend API calls as defense-in-depth to eliminate unnecessary 307 redirects entirely.