### PR TITLE
feat: #185 - Add create supplier to the Revisión Tarjetas page

### DIFF
--- a/.claude/commands/conditional_docs.md
+++ b/.claude/commands/conditional_docs.md
@@ -1932,3 +1932,11 @@ This prompt helps you determine what documentation you should read based on the 
     - When adding or changing actions in the lightbox DialogActions bar
     - When modifying filename generation for downloaded card images
     - When troubleshooting download behavior for data URI or HTTP URL images
+
+- app_docs/feature-d3b666c5-create-supplier-card-review.md
+  - Conditions:
+    - When modifying the "Crear Proveedor" button on CardReviewPage
+    - When working with supplier creation from business card captures
+    - When modifying the useCardReview hook's createSupplierFromCard method
+    - When working with the actions column on the Card Review page
+    - When troubleshooting supplier creation flow from card review

--- a/.claude/commands/e2e/test_create_supplier_card_review.md
+++ b/.claude/commands/e2e/test_create_supplier_card_review.md
@@ -1,0 +1,95 @@
+# E2E Test: Create Supplier from Card Review Page
+
+## User Story
+
+As a back-office team member reviewing trade fair captures
+I want to create a supplier directly from the Card Review page after editing extracted data
+So that I don't have to navigate back to the Card Capture page to complete the supplier creation workflow
+
+## Test Steps
+
+### Step 1: Navigate to Card Review Page
+1. Open the application at the base URL
+2. Login with test credentials (if required)
+3. Navigate to `/card-review` page using the sidebar navigation or direct URL
+4. **Verify** page title "Revisión de Tarjetas" is visible
+5. **Verify** the captures table is visible
+6. **Screenshot**: `01_card_review_page_loaded.png`
+
+### Step 2: Filter by Extracted Status
+1. Click the "Extraídas" filter tab/button
+2. **Verify** the filter is selected
+3. **Verify** only cards with "Extraído" status are shown (if any exist)
+4. **Screenshot**: `02_filtered_extracted.png`
+
+### Step 3: Verify "Crear Proveedor" Button on Extracted Cards
+1. If extracted cards exist without a linked supplier:
+   - **Verify** a "Crear Proveedor" button is visible in the actions column
+   - **Verify** the button has a PersonAdd icon
+   - **Verify** the button is a contained primary button (size small)
+2. If no extracted cards exist, switch back to "Todos" filter and note there are no testable cards
+3. **Screenshot**: `03_create_supplier_button.png`
+
+### Step 4: Verify "Proveedor vinculado" Chip on Confirmed Cards
+1. Switch to "Confirmadas" filter tab
+2. If confirmed cards with a linked supplier exist:
+   - **Verify** a "Proveedor vinculado" chip is visible (outlined, primary color, with CheckCircle icon)
+   - **Verify** the "Crear Proveedor" button does NOT appear on confirmed cards
+3. **Screenshot**: `04_confirmed_cards_chip.png`
+
+### Step 5: Click "Crear Proveedor" on an Extracted Card
+1. Switch back to "Extraídas" filter
+2. If an extracted card without a linked supplier exists:
+   - Click the "Crear Proveedor" button
+   - **Verify** the button text changes to "Creando..." with a spinner (CircularProgress)
+   - **Verify** the button is disabled during creation
+3. Wait for the operation to complete
+4. **Screenshot**: `05_creating_supplier_loading.png`
+
+### Step 6: Verify Supplier Creation Result
+1. If creation succeeds:
+   - **Verify** a success snackbar appears containing the supplier name
+   - **Verify** the card status changes to "Confirmado"
+   - **Verify** a "Proveedor vinculado" chip appears replacing the button
+   - **Verify** the "Crear Proveedor" button is no longer visible on that card
+2. If duplicate detected:
+   - **Verify** an error snackbar appears with "Duplicado detectado" message
+3. **Screenshot**: `06_creation_result.png`
+
+### Step 7: Verify Existing Approve Button Still Works
+1. Switch to "Extraídas" filter
+2. If extracted cards remain:
+   - **Verify** the "Aprobar" button is still visible alongside or instead of "Crear Proveedor"
+   - **Verify** both buttons are functional (do not click Aprobar, just verify it is present)
+3. **Screenshot**: `07_approve_button_present.png`
+
+### Step 8: Verify Button Not Shown for Non-Extracted Statuses
+1. Switch to "Pendientes" filter
+2. If pending cards exist:
+   - **Verify** the "Crear Proveedor" button does NOT appear on pending cards
+3. Switch to "Rechazadas" filter
+4. If rejected cards exist:
+   - **Verify** the "Crear Proveedor" button does NOT appear on rejected cards
+5. **Screenshot**: `08_button_not_on_other_statuses.png`
+
+## Success Criteria
+
+- [ ] Card Review page loads at `/card-review` with title "Revisión de Tarjetas"
+- [ ] "Crear Proveedor" button appears in the actions column for cards with status `extracted` and no linked supplier
+- [ ] "Crear Proveedor" button does NOT appear on confirmed, rejected, pending, or failed cards
+- [ ] Clicking "Crear Proveedor" shows loading state ("Creando..." with spinner)
+- [ ] Button is disabled during supplier creation to prevent double-clicks
+- [ ] On successful creation, a success snackbar shows the supplier name
+- [ ] On successful creation, the card status updates to "Confirmado"
+- [ ] After creation, a "Proveedor vinculado" chip appears instead of the button
+- [ ] Duplicate suppliers are detected and shown as error snackbar
+- [ ] The existing "Aprobar" button remains functional alongside "Crear Proveedor"
+- [ ] All UI text is in Spanish (Colombian)
+- [ ] No console errors during test execution
+
+## Notes
+
+- The "Crear Proveedor" button uses the same API endpoint as the CardCapturePage: `POST /api/extract/business-cards/{id}/create-supplier`
+- The existing "Aprobar" button is kept alongside "Crear Proveedor" for batch workflow compatibility
+- AI extraction may not be available in all test environments — if no extracted cards exist, structural validation is sufficient
+- Duplicate detection checks by email (case-insensitive) and phone number

--- a/app_docs/agentic_kpis.md
+++ b/app_docs/agentic_kpis.md
@@ -8,13 +8,13 @@ Summary metrics across all ADW runs.
 
 | Metric            | Value       | Last Updated |
 | ----------------- | ----------- | ------------ |
-| Current Streak    | 11          | 2026-03-10   |
-| Longest Streak    | 11          | 2026-03-10   |
-| Total Plan Size   | 1959 lines  | 2026-03-10   |
-| Largest Plan Size | 292 lines   | 2026-03-10   |
-| Total Diff Size   | 6260 lines  | 2026-03-10   |
-| Largest Diff Size | 1559 lines  | 2026-03-10   |
-| Average Presence  | 1.0         | 2026-03-10   |
+| Current Streak    | 12          | 2026-03-11   |
+| Longest Streak    | 12          | 2026-03-11   |
+| Total Plan Size   | 2113 lines  | 2026-03-11   |
+| Largest Plan Size | 292 lines   | 2026-03-11   |
+| Total Diff Size   | 6666 lines  | 2026-03-11   |
+| Largest Diff Size | 1559 lines  | 2026-03-11   |
+| Average Presence  | 1.0         | 2026-03-11   |
 
 ## ADW KPIs
 
@@ -33,3 +33,4 @@ Detailed metrics for individual ADW workflow runs.
 | 2026-03-10 | a973c501 | 170          | /feature    | 1        | 130                | 278/5/6                         | 2026-03-10 | 2026-03-10 |
 | 2026-03-10 | 2734e661 | 171          | /feature    | 1        | 144                | 388/8/6                         | 2026-03-10 | 2026-03-10 |
 | 2026-03-10 | f1974dcd | 172          | /feature    | 1        | 199                | 386/3/6                         | 2026-03-10 | 2026-03-10 |
+| 2026-03-11 | d3b666c5 | 185          | /feature    | 1        | 154                | 405/1/7                         | 2026-03-11 | 2026-03-11 |

--- a/app_docs/feature-d3b666c5-create-supplier-card-review.md
+++ b/app_docs/feature-d3b666c5-create-supplier-card-review.md
@@ -1,0 +1,64 @@
+# Create Supplier from Card Review Page
+
+**ADW ID:** d3b666c5
+**Date:** 2026-03-11
+**Specification:** specs/issue-185-adw-d3b666c5-sdlc_planner-create-supplier-card-review.md
+
+## Overview
+
+Adds a dedicated "Crear Proveedor" button to the Card Review page so users can create a supplier directly after reviewing extracted business card data, without navigating back to the Card Capture page. This eliminates a UX friction point during trade fairs where speed matters.
+
+## What Was Built
+
+- "Crear Proveedor" button in the Card Review page actions column for extracted cards without a linked supplier
+- Loading state with spinner and "Creando..." text during supplier creation
+- Snackbar feedback for success, duplicate detection, email status, and errors
+- "Proveedor vinculado" chip displayed on confirmed cards with a linked supplier
+- `createSupplierFromCard` method in the `useCardReview` hook with per-row loading tracking
+- E2E test specification for the full create-supplier-from-card-review workflow
+
+## Technical Implementation
+
+### Files Modified
+
+- `apps/Client/src/hooks/kompass/useCardReview.ts`: Added `createSupplierFromCard` method and `creatingSupplierIds` state (Set-based per-row loading tracking). On success, updates card status to `confirmed` with `supplier_id`. On duplicate, sets status to `rejected`.
+- `apps/Client/src/pages/kompass/CardReviewPage.tsx`: Added `PersonAddIcon` import, `handleCreateSupplier` handler with snackbar messaging, "Crear Proveedor" button (visible for `extracted` status without `supplier_id`), and "Proveedor vinculado" chip (visible for `confirmed` status with `supplier_id`).
+- `.claude/commands/e2e/test_create_supplier_card_review.md`: New E2E test file validating the button visibility, loading states, result feedback, and status transitions.
+- `playwright-mcp-config.json`: Minor update for E2E test configuration.
+
+### Key Changes
+
+- The `createSupplierFromCard` method in `useCardReview` calls the existing `businessCardService.createSupplierFromCard()` API — no backend changes were needed
+- Per-row loading state uses a `Set<string>` pattern (matching the CardCapturePage approach) to track which card IDs are being processed
+- The button is placed before the existing "Aprobar" button in the actions column for visual priority
+- Duplicate detection updates the card status to `rejected` in local state
+- The existing "Aprobar" button is preserved for batch-compatible approval workflows
+
+## How to Use
+
+1. Navigate to the **Revisión de Tarjetas** page (`/card-review`)
+2. Review extracted business card data in the table
+3. For cards with "Extraído" status, click the **Crear Proveedor** button in the actions column
+4. The button shows a loading spinner with "Creando..." while processing
+5. A snackbar notification appears with the result:
+   - **Success**: Supplier name and email status
+   - **Duplicate**: Error message with existing supplier name
+   - **Warning**: Supplier created but email failed or no email address found
+6. After successful creation, the card shows a "Proveedor vinculado" chip
+
+## Configuration
+
+No additional configuration required. Uses the existing `POST /api/extract/business-cards/{id}/create-supplier` endpoint.
+
+## Testing
+
+- **TypeScript**: `cd apps/Client && npx tsc --noEmit`
+- **Build**: `cd apps/Client && npm run build`
+- **Backend**: `cd apps/Server && python -m pytest tests/ -v --tb=short`
+- **E2E**: Run `/test_e2e` then execute `e2e:test_create_supplier_card_review`
+
+## Notes
+
+- No backend changes were required — the API endpoint, service logic, and duplicate detection already existed
+- The "Aprobar" button remains alongside "Crear Proveedor" because it supports batch workflows (batch approve selected cards)
+- The snackbar messaging matches the same pattern used on the CardCapturePage for consistency

--- a/apps/Client/src/hooks/kompass/useCardReview.ts
+++ b/apps/Client/src/hooks/kompass/useCardReview.ts
@@ -23,6 +23,8 @@ export interface UseCardReviewReturn extends UseCardReviewState {
   rejectCard: (captureId: string, reason?: string) => Promise<void>;
   batchApprove: (captureIds: string[]) => Promise<void>;
   batchReject: (captureIds: string[], reason?: string) => Promise<void>;
+  createSupplierFromCard: (captureId: string) => Promise<SupplierFromCardResult>;
+  creatingSupplierIds: Set<string>;
   toggleSelection: (captureId: string) => void;
   toggleSelectAll: () => void;
   setStatusFilter: (status: BusinessCardCaptureStatus | null) => void;
@@ -37,6 +39,7 @@ export function useCardReview(): UseCardReviewReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [creatingSupplierIds, setCreatingSupplierIds] = useState<Set<string>>(new Set());
 
   const fetchCaptures = useCallback(async (filter?: BusinessCardCaptureStatus | null) => {
     console.log('INFO [useCardReview]: Fetching captures');
@@ -179,6 +182,41 @@ export function useCardReview(): UseCardReviewReturn {
     }
   }, [rejectCard]);
 
+  const createSupplierFromCard = useCallback(async (captureId: string): Promise<SupplierFromCardResult> => {
+    console.log(`INFO [useCardReview]: Creating supplier from card ${captureId}`);
+    setCreatingSupplierIds(prev => new Set(prev).add(captureId));
+
+    try {
+      const result = await businessCardService.createSupplierFromCard(captureId);
+
+      setCaptures(prev =>
+        prev.map(c => {
+          if (c.id !== captureId) return c;
+          if (result.is_duplicate) {
+            return { ...c, status: 'rejected' as BusinessCardCaptureStatus };
+          }
+          return {
+            ...c,
+            status: 'confirmed' as BusinessCardCaptureStatus,
+            supplier_id: result.supplier_id ?? null,
+          };
+        })
+      );
+
+      console.log(`INFO [useCardReview]: Supplier created successfully from card ${captureId}`);
+      return result;
+    } catch (err) {
+      console.error('ERROR [useCardReview]: Failed to create supplier from card:', err);
+      throw err;
+    } finally {
+      setCreatingSupplierIds(prev => {
+        const next = new Set(prev);
+        next.delete(captureId);
+        return next;
+      });
+    }
+  }, []);
+
   const toggleSelection = useCallback((captureId: string) => {
     setSelectedIds(prev => {
       const next = new Set(prev);
@@ -227,6 +265,8 @@ export function useCardReview(): UseCardReviewReturn {
     rejectCard,
     batchApprove,
     batchReject,
+    createSupplierFromCard,
+    creatingSupplierIds,
     toggleSelection,
     toggleSelectAll,
     setStatusFilter,

--- a/apps/Client/src/pages/kompass/CardReviewPage.tsx
+++ b/apps/Client/src/pages/kompass/CardReviewPage.tsx
@@ -32,6 +32,7 @@ import ZoomInIcon from '@mui/icons-material/ZoomIn';
 import BrokenImageIcon from '@mui/icons-material/BrokenImage';
 import CloseIcon from '@mui/icons-material/Close';
 import DownloadIcon from '@mui/icons-material/Download';
+import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import { useLocation } from 'react-router-dom';
 import type { BusinessCardCaptureStatus } from '@/types/kompass';
 import { useCardReview } from '@/hooks/kompass/useCardReview';
@@ -174,6 +175,8 @@ export default function CardReviewPage() {
     rejectCard,
     batchApprove,
     batchReject,
+    createSupplierFromCard,
+    creatingSupplierIds,
     toggleSelection,
     toggleSelectAll,
     setStatusFilter,
@@ -236,6 +239,25 @@ export default function CardReviewPage() {
       }
     } catch {
       setSnackbar({ message: 'Error al aprobar la tarjeta', severity: 'error' });
+    }
+  };
+
+  const handleCreateSupplier = async (captureId: string) => {
+    try {
+      const result = await createSupplierFromCard(captureId);
+      if (result.is_duplicate) {
+        setSnackbar({ message: `Duplicado detectado: ${result.duplicate_supplier_name || 'proveedor existente'}`, severity: 'error' });
+      } else if (result.email_sent) {
+        setSnackbar({ message: `Proveedor "${result.supplier_name}" creado. Correo de seguimiento enviado`, severity: 'success' });
+      } else if (result.email_error) {
+        setSnackbar({ message: `Proveedor "${result.supplier_name}" creado. Error al enviar correo de seguimiento`, severity: 'warning' });
+      } else if (result.no_email_address) {
+        setSnackbar({ message: `Proveedor "${result.supplier_name}" creado. No se encontró correo electrónico — seguimiento manual requerido`, severity: 'warning' });
+      } else {
+        setSnackbar({ message: `Proveedor "${result.supplier_name}" creado exitosamente`, severity: 'success' });
+      }
+    } catch {
+      setSnackbar({ message: 'Error al crear proveedor', severity: 'error' });
     }
   };
 
@@ -584,6 +606,27 @@ export default function CardReviewPage() {
                               <DownloadIcon fontSize="small" />
                             </IconButton>
                           </Tooltip>
+                        )}
+                        {capture.status === 'extracted' && !capture.supplier_id && (
+                          <Button
+                            variant="contained"
+                            color="primary"
+                            size="small"
+                            startIcon={creatingSupplierIds.has(capture.id) ? <CircularProgress size={16} /> : <PersonAddIcon />}
+                            onClick={() => handleCreateSupplier(capture.id)}
+                            disabled={creatingSupplierIds.has(capture.id) || isProcessing}
+                          >
+                            {creatingSupplierIds.has(capture.id) ? 'Creando...' : 'Crear Proveedor'}
+                          </Button>
+                        )}
+                        {capture.status === 'confirmed' && capture.supplier_id && (
+                          <Chip
+                            icon={<CheckCircleIcon />}
+                            label="Proveedor vinculado"
+                            color="primary"
+                            size="small"
+                            variant="outlined"
+                          />
                         )}
                         {canApprove(capture.status) && (
                           <Tooltip title="Aprobar">

--- a/playwright-mcp-config.json
+++ b/playwright-mcp-config.json
@@ -7,7 +7,7 @@
     }
   },
   "recording": {
-    "dir": "/mnt/c/Users/user/danke_apps/Kompass/trees/f1974dcd/videos",
+    "dir": "/mnt/c/Users/user/danke_apps/Kompass/trees/d3b666c5/videos",
     "enabled": true
   }
 }

--- a/specs/issue-185-adw-d3b666c5-sdlc_planner-create-supplier-card-review.md
+++ b/specs/issue-185-adw-d3b666c5-sdlc_planner-create-supplier-card-review.md
@@ -1,0 +1,154 @@
+# Feature: Add Create Supplier to Card Review Page
+
+## Metadata
+issue_number: `185`
+adw_id: `d3b666c5`
+issue_json: `{"number":185,"title":"Add create supplier to the <Revisión Tarjetas> page","body":"When the user takes the picture, the app sends the user to the <Revisión Tarjetas> screen. Here, the user can adjust the extracted data. After adjusting, the user has to go back to the <Captura Tarjetas> screen to create the supplier. To improve the UX, the user should also be able to create the supplier from the <Revisión Tarjetas> screen."}`
+
+## Feature Description
+Add an explicit "Crear Proveedor" (Create Supplier) button to the Card Review page (`Revisión Tarjetas`) so users can create a supplier directly after reviewing and editing extracted business card data, without having to navigate back to the Card Capture page.
+
+Currently, the Card Review page has an "Aprobar" (Approve) button that internally creates a supplier, but the UX does not make this clear. The Card Capture page has an explicit "Crear Proveedor" button with loading states and inline result feedback. This feature brings the same explicit supplier-creation UX to the Card Review page by adding a dedicated "Crear Proveedor" button with proper loading states, result feedback, and a "Proveedor vinculado" (Linked Supplier) chip for confirmed cards.
+
+## User Story
+As a trade fair attendee using Kompass
+I want to create a supplier directly from the Card Review page after editing the extracted data
+So that I don't have to navigate back to the Card Capture page to complete the supplier creation workflow
+
+## Problem Statement
+After capturing a business card photo, the app navigates the user to the Card Review page where they can edit the extracted data. However, to create a supplier from the card, the user must navigate back to the Card Capture page and find the card there to click "Crear Proveedor". This extra navigation step is a UX friction point, especially during busy trade fairs where speed matters.
+
+## Solution Statement
+Add a dedicated "Crear Proveedor" button to the Card Review page's actions column for each card with status `extracted` and no linked supplier. The button will:
+1. Call the existing `POST /api/extract/business-cards/{id}/create-supplier` API endpoint
+2. Show a loading spinner with "Creando..." text while the request is in progress
+3. Display result feedback via snackbar (success, duplicate, email status)
+4. Update the card's local state to `confirmed` with the supplier_id on success
+5. Show a "Proveedor vinculado" chip for confirmed cards with a linked supplier
+
+No backend changes are needed — the API endpoint and service logic already exist.
+
+## Relevant Files
+Use these files to implement the feature:
+
+- `apps/Client/src/pages/kompass/CardReviewPage.tsx` — The Card Review page component. Add the "Crear Proveedor" button in the actions column, loading states, and result feedback. Reference the existing "Crear Proveedor" pattern from CardCapturePage.
+- `apps/Client/src/hooks/kompass/useCardReview.ts` — The Card Review hook. Add a `createSupplierFromCard` method that calls `businessCardService.createSupplierFromCard()` and manages loading/result state.
+- `apps/Client/src/pages/kompass/CardCapturePage.tsx` — Reference file. Contains the existing "Crear Proveedor" button pattern with loading states (`creatingSupplierIds`), result tracking (`supplierResults`), and inline feedback. Use this as the pattern to follow.
+- `apps/Client/src/services/kompassService.ts` — Contains `businessCardService.createSupplierFromCard()` (line ~1289). Already exists — no changes needed, just reference for the API call signature.
+- `apps/Client/src/types/kompass.ts` — Contains `SupplierFromCardResult` and `BusinessCardCapture` types (lines 1052-1085). Already exists — no changes needed.
+- `.claude/commands/test_e2e.md` — Read to understand how to create and run E2E tests.
+- `.claude/commands/e2e/test_basic_query.md` — Read as an example E2E test file format.
+- `.claude/commands/e2e/test_auto_create_supplier_from_card.md` — Read as reference for supplier creation E2E test patterns.
+- `.claude/commands/e2e/test_card_review_page.md` — Read as reference for Card Review page E2E test patterns.
+
+### New Files
+- `.claude/commands/e2e/test_create_supplier_card_review.md` — New E2E test file to validate the "Crear Proveedor" button works on the Card Review page.
+
+## Implementation Plan
+### Phase 1: Foundation
+Add the `createSupplierFromCard` method and associated state to the `useCardReview` hook. This includes tracking which card IDs are currently being processed (loading state) and storing supplier creation results.
+
+### Phase 2: Core Implementation
+Add the "Crear Proveedor" button to the CardReviewPage actions column. The button appears for cards with status `extracted` and no `supplier_id`. It shows a loading spinner while creating, and displays result feedback via snackbar. Also add a "Proveedor vinculado" chip for confirmed cards that already have a linked supplier.
+
+### Phase 3: Integration
+Create an E2E test to validate the full workflow: navigate to Card Review, verify the "Crear Proveedor" button appears for extracted cards, verify loading state, verify result feedback, and verify the card status updates after supplier creation. Run all validation commands to ensure zero regressions.
+
+## Step by Step Tasks
+
+### Step 1: Create E2E test file
+- Read `.claude/commands/test_e2e.md` to understand the E2E test format
+- Read `.claude/commands/e2e/test_basic_query.md` for the E2E test template
+- Read `.claude/commands/e2e/test_auto_create_supplier_from_card.md` for supplier creation test patterns
+- Read `.claude/commands/e2e/test_card_review_page.md` for Card Review page test patterns
+- Create `.claude/commands/e2e/test_create_supplier_card_review.md` with these test steps:
+  1. Navigate to `/card-review` and verify the page loads with the table
+  2. Filter by "Extraídas" status to show only extracted cards
+  3. Verify a "Crear Proveedor" button appears in the actions column for extracted cards without a linked supplier
+  4. Verify that confirmed cards show a "Proveedor vinculado" chip instead of the button
+  5. Click "Crear Proveedor" on an extracted card and verify the button shows loading state ("Creando..." with spinner)
+  6. Verify a success snackbar appears with the supplier name after creation
+  7. Verify the card status changes to "Confirmado" and the "Proveedor vinculado" chip appears
+  8. Take screenshots at each step for validation
+
+### Step 2: Add `createSupplierFromCard` method to useCardReview hook
+- Open `apps/Client/src/hooks/kompass/useCardReview.ts`
+- Add state for tracking creating supplier IDs: `creatingSupplierIds` as a `Set<string>`
+- Add `createSupplierFromCard` method to the hook that:
+  - Adds the captureId to `creatingSupplierIds` set
+  - Calls `businessCardService.createSupplierFromCard(captureId)`
+  - On success: updates the capture's status to `confirmed` and sets `supplier_id` in local state
+  - On duplicate: updates the capture's status to `rejected` in local state
+  - Removes the captureId from `creatingSupplierIds` in the `finally` block
+  - Returns the `SupplierFromCardResult` for the page to handle snackbar messaging
+- Add `createSupplierFromCard` and `creatingSupplierIds` to the `UseCardReviewReturn` interface and the hook's return object
+
+### Step 3: Add "Crear Proveedor" button to CardReviewPage
+- Open `apps/Client/src/pages/kompass/CardReviewPage.tsx`
+- Import `PersonAddIcon` from `@mui/icons-material/PersonAdd` (used for the button icon, matching CardCapturePage pattern)
+- Destructure `createSupplierFromCard` and `creatingSupplierIds` from `useCardReview()`
+- Add a `handleCreateSupplier` async function (similar to `handleApprove`) that:
+  - Calls `createSupplierFromCard(captureId)`
+  - On success: shows snackbar with supplier name and email status (same messaging as `handleApprove`)
+  - On duplicate: shows error snackbar with duplicate supplier name
+  - On error: shows error snackbar
+- In the actions column (`<TableCell>` at line ~570), add the "Crear Proveedor" button:
+  - Visible when: `capture.status === 'extracted' && !capture.supplier_id`
+  - Button text: "Crear Proveedor" (or "Creando..." when loading)
+  - Icon: `PersonAddIcon` (or `CircularProgress` spinner when loading)
+  - Color: `primary`, variant: `contained`, size: `small`
+  - Disabled when: `creatingSupplierIds.has(capture.id)` or `isProcessing`
+  - onClick: calls `handleCreateSupplier(capture.id)`
+- Add a "Proveedor vinculado" chip for cards with `status === 'confirmed' && supplier_id`:
+  - Uses `CheckCircleIcon` as the chip icon
+  - Color: `primary`, size: `small`, variant: `outlined`
+  - Label: "Proveedor vinculado"
+- Keep the existing "Aprobar" button as-is (it provides batch-compatible approval workflow)
+- Place "Crear Proveedor" button BEFORE the "Aprobar" button in the actions to give it visual priority as the primary action
+
+### Step 4: Run validation commands
+- Run `cd apps/Server && python -m pytest tests/ -v --tb=short` to validate no backend regressions
+- Run `cd apps/Client && npx tsc --noEmit` to validate TypeScript compiles with no errors
+- Run `cd apps/Client && npm run build` to validate the production build succeeds
+- Read `.claude/commands/test_e2e.md`, then read and execute `.claude/commands/e2e/test_create_supplier_card_review.md` to validate the feature works end-to-end
+
+## Testing Strategy
+### Unit Tests
+No new unit tests are needed. The backend API endpoint and service logic are already tested. The frontend changes are UI-only (adding a button that calls an existing service method) and will be validated by the E2E test and TypeScript compilation.
+
+### Edge Cases
+- Card with status `extracted` but already has a `supplier_id` (shouldn't show button — handled by condition check)
+- Duplicate supplier detection — button should show error snackbar and update status to `rejected`
+- Card with status `confirmed` — should show "Proveedor vinculado" chip, not the button
+- Card with status `pending`, `processing`, or `failed` — should not show "Crear Proveedor" button
+- Multiple rapid clicks on "Crear Proveedor" — button is disabled while loading, preventing double submission
+- Network error during supplier creation — should show error snackbar and not change card status
+- Email send failure — should show warning snackbar (supplier created but email failed)
+- No email address on card — should show warning snackbar (manual follow-up needed)
+
+## Acceptance Criteria
+- A "Crear Proveedor" button appears in the Card Review page actions column for cards with status `extracted` and no linked supplier
+- Clicking "Crear Proveedor" shows a loading state (spinner + "Creando..." text)
+- On successful supplier creation, a success snackbar shows the supplier name
+- On successful creation, the card status updates to "Confirmado" in the table
+- After creation, a "Proveedor vinculado" chip appears instead of the button
+- Duplicate suppliers are detected and shown as error snackbar
+- Email status (sent, failed, no email) is communicated via appropriate snackbar severity
+- The button is disabled during processing to prevent double-clicks
+- TypeScript compiles with zero errors
+- Production build succeeds
+- No regressions in existing tests
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `cd apps/Server && python -m pytest tests/ -v --tb=short` — Run Server tests to validate the feature works with zero regressions
+- `cd apps/Client && npx tsc --noEmit` — Run Client type check to validate the feature works with zero regressions
+- `cd apps/Client && npm run build` — Run Client build to validate the feature works with zero regressions
+- Read `.claude/commands/test_e2e.md`, then read and execute `.claude/commands/e2e/test_create_supplier_card_review.md` E2E test file to validate this functionality works
+
+## Notes
+- No backend changes are required. The `POST /api/extract/business-cards/{id}/create-supplier` endpoint already exists and handles supplier creation, duplicate detection, email sending, and status updates.
+- The existing "Aprobar" button is kept alongside "Crear Proveedor" because "Aprobar" supports the batch workflow (batch approve selected cards). The "Crear Proveedor" button provides explicit, individual supplier creation UX.
+- The `businessCardService.createSupplierFromCard()` method in `kompassService.ts` already exists (line ~1289) and is the same method used on the CardCapturePage.
+- The pattern for loading states follows the CardCapturePage approach: tracking IDs in a `Set<string>` for per-row loading indicators.


### PR DESCRIPTION
## Summary

Closes #185

Adds a dedicated "Crear Proveedor" (Create Supplier) button to the Card Review page (`Revisión Tarjetas`) so users can create a supplier directly after reviewing and editing extracted business card data, without navigating back to the Card Capture page.

### Problem
After capturing a business card photo, the app navigates to the Card Review page for data editing. However, to create a supplier, the user had to navigate back to the Card Capture page — an unnecessary UX friction point during busy trade fairs.

### Solution
- Add "Crear Proveedor" button in the Card Review page actions column for cards with status `extracted` and no linked supplier
- Show loading state (spinner + "Creando..." text) during supplier creation
- Display result feedback via snackbar (success, duplicate, email status)
- Show "Proveedor vinculado" chip for confirmed cards with a linked supplier
- No backend changes needed — uses the existing `POST /api/extract/business-cards/{id}/create-supplier` endpoint

## Implementation Plan
📋 [Implementation spec](specs/issue-185-adw-d3b666c5-sdlc_planner-create-supplier-card-review.md)

## What Was Done
- [x] Created implementation plan with detailed step-by-step tasks
- [ ] Add `createSupplierFromCard` method to `useCardReview` hook
- [ ] Add "Crear Proveedor" button to CardReviewPage actions column
- [ ] Add "Proveedor vinculado" chip for confirmed cards
- [ ] Create E2E test for the new feature
- [ ] Run validation commands (TypeScript, build, tests)

## Key Changes
| File | Change |
|------|--------|
| `specs/issue-185-adw-d3b666c5-sdlc_planner-create-supplier-card-review.md` | Implementation plan for the feature |

## ADW Tracking
- **ADW ID:** `d3b666c5`
- **Phase:** Planning (SDLC Planner)